### PR TITLE
Rework package imports 

### DIFF
--- a/Tools/Cluster.py
+++ b/Tools/Cluster.py
@@ -14,7 +14,18 @@
 #
 # =============================================================================================
 
-from Tools import *
+import random
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+from sklearn.cluster import KMeans
+import Tools.genMask as genMask
+
+# from sklearn.datasets import make_regression
+# from sklearn.ensemble import BaggingRegressor
+# from sklearn.metrics import mean_squared_error, r2_score
+# from sklearn.model_selection import LeaveOneOut
+# from sklearn.tree import DecisionTreeRegressor
 
 
 ##@param[in]   packdata               packaged data

--- a/Tools/__init__.py
+++ b/Tools/__init__.py
@@ -14,51 +14,51 @@
 #
 # =============================================================================================
 
-import calendar
-# Ready-made
-import os
+# import calendar
+# # Ready-made
+# import os
 
-import matplotlib
-import numpy as np
-import pandas as pd
-from netCDF4 import Dataset
+# import matplotlib
+# import numpy as np
+# import pandas as pd
+# from netCDF4 import Dataset
 
-matplotlib.use("Agg")
-import itertools
-import json
-import random
-import sys
-import warnings
-from collections import Counter
+# matplotlib.use("Agg")
+# import itertools
+# import json
+# import random
+# import sys
+# import warnings
+# from collections import Counter
 
-import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
-from imblearn.over_sampling import SMOTE
-from mpl_toolkits.basemap import Basemap
-from pandas import DataFrame, Series
-from scipy import stats
-from sklearn.cluster import Birch, KMeans
-from sklearn.datasets import make_regression
-from sklearn.ensemble import BaggingRegressor
-from sklearn.metrics import mean_squared_error, r2_score
-from sklearn.model_selection import LeaveOneOut
-from sklearn.tree import DecisionTreeRegressor
+# import matplotlib.colors as mcolors
+# import matplotlib.pyplot as plt
+# from imblearn.over_sampling import SMOTE
+# from mpl_toolkits.basemap import Basemap
+# from pandas import DataFrame, Series
+# from scipy import stats
+# from sklearn.cluster import Birch, KMeans
+# from sklearn.datasets import make_regression
+# from sklearn.ensemble import BaggingRegressor
+# from sklearn.metrics import mean_squared_error, r2_score
+# from sklearn.model_selection import LeaveOneOut
+# from sklearn.tree import DecisionTreeRegressor
 
-warnings.simplefilter(action="ignore")
-sys.path.append(os.path.dirname(__file__))
+# warnings.simplefilter(action="ignore")
+# sys.path.append(os.path.dirname(__file__))
 
-import check
-import Cluster
-import encode
-import eval_plot_loocv_un
-import eval_plot_un
-import extract_X
-import forcing
-import genMask
-import mapGlobe
-import ML
-import MLeval
-import train
-# Home-made
-from classes import auxiliary, pack
-from readvar import readvar
+# import check
+# import Cluster
+# import encode
+# import eval_plot_loocv_un
+# import eval_plot_un
+# import extract_X
+# import forcing
+# import genMask
+# import mapGlobe
+# import ML
+# import MLeval
+# import train
+# # Home-made
+# from classes import auxiliary, pack
+# from readvar import readvar

--- a/Tools/genMask.py
+++ b/Tools/genMask.py
@@ -14,7 +14,8 @@
 #
 # =============================================================================================
 
-from Tools import *
+import numpy as np
+from netCDF4 import Dataset
 
 
 ##@param[in]   packdata               packaged data

--- a/Tools/readvar.py
+++ b/Tools/readvar.py
@@ -14,7 +14,10 @@
 #
 # =============================================================================================
 
-from Tools import *
+import numpy as np
+from netCDF4 import Dataset
+import Tools.check as check
+import calendar
 
 
 ##@param[in]   packdata               packaged data

--- a/main.py
+++ b/main.py
@@ -15,12 +15,30 @@
  XXXX <License content>
 """
 
-import subprocess
-
-# added line
+import os
 import numpy as np
+import sys
+import subprocess
+from mpl_toolkits.basemap import Basemap
+import matplotlib.pyplot as plt
+import json
+import random
+from netCDF4 import Dataset
 
-from Tools import *
+import Tools.check as check
+from Tools.classes import pack
+from Tools.classes import auxiliary
+from Tools.readvar import readvar
+
+import Tools.Cluster as Cluster
+import Tools.forcing as forcing
+
+import Tools.ML as ML
+import Tools.genMask as genMask
+
+import Tools.eval_plot_un as eval_plot_un
+import Tools.eval_plot_loocv_un as eval_plot_loocv_un
+
 
 # print Python version
 print(sys.version)


### PR DESCRIPTION
All imports are currently handled by `__init__.py` in `Tools`, and `from Tools import *` is used at the top of all files. This PR attempts to rework package imports by including only what is needed for each file.   

Fixes #43 

This PR is ready for review once the following are addressed:

- [ ] Consider how `__init__.py` can still be utilised.
- [ ] Simple smoke test using github actions 