### PR TITLE
Fix regressions introduced by ordering imports, and fix evaluation step

### DIFF
--- a/Tools/__init__.py
+++ b/Tools/__init__.py
@@ -15,6 +15,7 @@
 # =============================================================================================
 
 import calendar
+
 # Ready-made
 import os
 
@@ -28,7 +29,6 @@ import itertools
 import json
 import random
 import sys
-import warnings
 from collections import Counter
 
 import matplotlib.colors as mcolors
@@ -44,21 +44,23 @@ from sklearn.metrics import mean_squared_error, r2_score
 from sklearn.model_selection import LeaveOneOut
 from sklearn.tree import DecisionTreeRegressor
 
+import warnings
+
 warnings.simplefilter(action="ignore")
 sys.path.append(os.path.dirname(__file__))
 
-import check
-import Cluster
-import encode
-import eval_plot_loocv_un
-import eval_plot_un
-import extract_X
-import forcing
-import genMask
-import mapGlobe
-import ML
-import MLeval
-import train
 # Home-made
-from classes import auxiliary, pack
+from classes import pack, auxiliary
+import check
+import genMask
+import extract_X
+import encode
 from readvar import readvar
+import Cluster
+import train
+import mapGlobe
+import MLeval
+import eval_plot_un
+import eval_plot_loocv_un
+import ML
+import forcing

--- a/Tools/eval_plot_un.py
+++ b/Tools/eval_plot_un.py
@@ -120,7 +120,7 @@ def plot_metric(data_path, npfts, ipool, subLabel, dims, sect_n, xTickLabel):
 
         my_x_ticks = np.arange(subps)
         axs[0].set_xticks(my_x_ticks)
-        axs[0].set_xticklabels([""])
+        # axs[0].set_xticklabels([""])
         my_y_ticks = np.arange(npfts)
         axs[0].set_yticks(my_y_ticks)
         axs[0].set_yticklabels(yTickLabel)
@@ -148,7 +148,7 @@ def plot_metric(data_path, npfts, ipool, subLabel, dims, sect_n, xTickLabel):
                 )
         my_x_ticks = np.arange(subps)
         axs[1].set_xticks(my_x_ticks)
-        axs[1].set_xticklabels([""])
+        # axs[1].set_xticklabels([""])
         my_y_ticks = np.arange(npfts)
         axs[1].set_yticks(my_y_ticks)
         axs[1].set_yticklabels(yTickLabel)


### PR DESCRIPTION
The ordering of imports has introduced a regression. This PR reorders all imports so that the pipeline proceeds without error. 

In addition in the evaluation step we are met with several errors of the form.

```
ValueError: The number of FixedLocator locations (3), usually from a call to set_ticks, does not match the number of ticklabels (1).
```

This has been temporarily fixed by commenting out the line. 