### PR TITLE
Fix errors introduced by new config format

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ XXXX <License content>
 """
 
 from Tools import *
-from DEF_Trunk import config
 
 # added line
 import numpy as np
@@ -34,17 +33,23 @@ if len(sys.argv) < 2:
     dir_def = "DEF_Trunk/"
 else:
     dir_def = sys.argv[1]
+    sys.path.append(dir_def)
+    import config
 
 # Define task
-itask = config.tasks
+itask = str(config.tasks)
 
 logfile = open(config.logfile, "w", buffering=1)
 check.display("DEF directory: " + dir_def, logfile)
-check.display("running task: %s" % str(itask), logfile)
+check.display("running task: %s" % itask, logfile)
 
 # Define task
 resultpath = config.results_dir
 check.display("results are stored at: " + resultpath, logfile)
+
+# Create results directory if it does not exist
+if not os.path.exists(resultpath):
+    os.makedirs(resultpath)
 
 # Read list of variables
 with open(dir_def + "varlist.json", "r") as f:
@@ -70,6 +75,8 @@ np.random.seed(iseed)
 check.display("random seed = %i" % iseed, logfile)
 # Define do leave-one-out crosee validation (loocv=1) or not (loocv=0)
 loocv = config.leave_one_out_cv
+
+print(itask)
 
 
 if "1" in itask:

--- a/main.py
+++ b/main.py
@@ -76,8 +76,6 @@ check.display("random seed = %i" % iseed, logfile)
 # Define do leave-one-out crosee validation (loocv=1) or not (loocv=0)
 loocv = config.leave_one_out_cv
 
-print(itask)
-
 
 if "1" in itask:
     #


### PR DESCRIPTION
This PR fixes the execution of SPINacc as errors were accidentally merged from #52:

- `DEF_Trunk` path was hardcoded. Now passing a different directory on the command line actually works. 
- The results directory was not created if it didn't exist
- Previously the tasks were skipped (as none of the tasks checks passed) as the list of tasks is instantiated as type integer in `config.py`.