### PR TITLE
Fix process based parallelism

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.12'
+          python-version: '3.9.21'
       - name: Install linting tools
         run: pip install ruff==0.9.1
       - name: ruff python interface checks

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -42,6 +42,7 @@ def mlmap_multidim(
     * Extract data from the dataset.
     * Train a machine learning model.
     * Extrapolate the model to all global pixels.
+    * Write the extrapolated values to the restart file.
     * Evaluate the model.
 
     Args:
@@ -119,7 +120,7 @@ def mlmap_multidim(
     ) = train.training_bat(combineXY, logfile, leave_one_out_cv, smote_bat, seed, alg)
 
     # 3. Extrapolate
-    Global_Predicted_Y_map = extrapolate_globally(
+    Global_Predicted_Y_map, Pred_Y_out, idx = extrapolate_globally(
         model,
         predY_train,
         pool_map,
@@ -139,18 +140,23 @@ def mlmap_multidim(
 
     # 4. Evaluate
     if (PFT_mask[ipft - 1] > 0).any():
-        return evaluate(
-            ipool,
-            ipft,
+        return (
+            evaluate(
+                ipool,
+                ipft,
+                varname,
+                ind,
+                ii,
+                model,
+                Global_Predicted_Y_map,
+                pool_map,
+                PFT_mask,
+                varlist,
+                model_out_dir,
+            ),
+            Pred_Y_out,
+            idx,
             varname,
-            ind,
-            ii,
-            model,
-            Global_Predicted_Y_map,
-            pool_map,
-            PFT_mask,
-            varlist,
-            model_out_dir,
         )
     else:
         check.display(
@@ -238,7 +244,8 @@ def extrapolate_globally(
     Returns:
         Global_Predicted_Y_map: Predicted map of target variables.
     """
-
+    Pred_Y_out = None
+    idx = None
     if not model:
         # Only a single value
         predY = np.where(pool_map == pool_map, predY_train.iloc[0], np.nan)
@@ -261,10 +268,11 @@ def extrapolate_globally(
         # some pixel with nan remain, so set them zero
         Pred_Y_out = np.nan_to_num(Pred_Y_out)
         idx = (..., *[i - 1 for i in ind], slice(None), slice(None))
-        restvar[idx] = Pred_Y_out
+        # breakpoint()
+        # restvar[idx] = Pred_Y_out
         # command = "restvar[...," + "%s," * len(ind) + ":,:]=Pred_Y_out[:]"
         # exec(command % tuple(ind - 1))
-    return Global_Predicted_Y_map
+    return Global_Predicted_Y_map, Pred_Y_out, idx
 
 
 def evaluate(
@@ -412,6 +420,8 @@ def ml_loop(
     # - old comment suggested that memory was exceeded outside loop
 
     restnc = Dataset(restfile, "a")
+    result = []
+
     Yvar = varlist["resp"]["variables"][ipool]
     for ii in Yvar:
         for jj in ii["name_prefix"]:
@@ -436,6 +446,7 @@ def ml_loop(
                             ipft = ind[ii["dim_loop"].index("pft")]
                         if ipft in ii["skip_loop"]["pft"]:
                             continue
+                        # inputs.append(
                         inputs.append(
                             (
                                 packdata,
@@ -458,28 +469,42 @@ def ml_loop(
                                 seed,
                             )
                         )
-                    # Debugging
-                    # if inputs:
-                    #     break
 
-                # Close netCDF file
+    # Close files
+    responseY.close()
     restnc.close()
 
-    # Run the MLmap_multidim function in parallel or serial
+    # # Run the MLmap_multidim function in parallel or serial
     if parallel:
         with ProcessPoolExecutor() as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list
             print("Number of workers ", executor._max_workers)
-            result = list(filter(None, executor.map(mlmap_multidim, *zip(*inputs))))
+            result, Pred_Y_out, idx, varname = zip(
+                *filter(None, executor.map(mlmap_multidim, *zip(*inputs)))
+            )
+            rest_state = list(zip(varname, idx, Pred_Y_out))
+            all_result = list(result)
+
     else:
         # Serial processing
-        result = []
+        all_result = []
+        rest_state = []
         for input in inputs:
             if input:
-                output = mlmap_multidim(*input)
-                if output:  # Filter out None results
-                    result.append(output)
+                result, Pred_Y_out, idx, varname = mlmap_multidim(*input)
+                if result:  # Filter out None results
+                    all_result.append(result)
+                    rest_state.append((varname, idx, Pred_Y_out))
 
-    return pd.DataFrame(result).set_index(["ivar", "ipft"]).sort_index()
+    # Modify restart file
+
+    restnc = Dataset(restfile, "a")
+    if rest_state:
+        for varname, idx, Pred_Y_out in rest_state:
+            if Pred_Y_out is not None:
+                restnc[varname][idx] = Pred_Y_out
+    restnc.close()
+
+    return pd.DataFrame(all_result).set_index(["ivar", "ipft"]).sort_index()

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -469,7 +469,7 @@ def ml_loop(
     if parallel:
         import multiprocessing
 
-        # multiprocessing.set_start_method("spawn", force=True)
+        multiprocessing.set_start_method("fork", force=True)
         with ProcessPoolExecutor(max_workers=1) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -467,9 +467,6 @@ def ml_loop(
 
     # Run the MLmap_multidim function in parallel or serial
     if parallel:
-        import multiprocessing
-
-        multiprocessing.set_start_method("spawn", force=True)
         with ProcessPoolExecutor(max_workers=1) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -468,11 +468,10 @@ def ml_loop(
     # Run the MLmap_multidim function in parallel or serial
     if parallel:
         with ProcessPoolExecutor() as executor:
-            from functools import partial
-
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
-            # All inputs are collected in  the result list
+            # All inputs are collected in the result list
+            print("Number of workers ", executor._max_workers)
             result = list(filter(None, executor.map(mlmap_multidim, *zip(*inputs))))
     else:
         # Serial processing

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -470,7 +470,7 @@ def ml_loop(
         import multiprocessing
 
         # multiprocessing.set_start_method("spawn", force=True)
-        with ProcessPoolExecutor(max_workers=2) as executor:
+        with ProcessPoolExecutor(max_workers=1) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -467,7 +467,10 @@ def ml_loop(
 
     # Run the MLmap_multidim function in parallel or serial
     if parallel:
-        with ProcessPoolExecutor() as executor:
+        import multiprocessing
+
+        multiprocessing.set_start_method("spawn", force=True)
+        with ProcessPoolExecutor(max_workers=4) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -467,7 +467,7 @@ def ml_loop(
 
     # Run the MLmap_multidim function in parallel or serial
     if parallel:
-        with ProcessPoolExecutor(max_workers=1) as executor:
+        with ProcessPoolExecutor() as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -469,7 +469,7 @@ def ml_loop(
     if parallel:
         import multiprocessing
 
-        multiprocessing.set_start_method("fork", force=True)
+        multiprocessing.set_start_method("spawn", force=True)
         with ProcessPoolExecutor(max_workers=1) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -470,7 +470,7 @@ def ml_loop(
         import multiprocessing
 
         # multiprocessing.set_start_method("spawn", force=True)
-        with ProcessPoolExecutor(max_workers=4) as executor:
+        with ProcessPoolExecutor(max_workers=2) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -469,7 +469,7 @@ def ml_loop(
     if parallel:
         import multiprocessing
 
-        multiprocessing.set_start_method("spawn", force=True)
+        # multiprocessing.set_start_method("spawn", force=True)
         with ProcessPoolExecutor(max_workers=4) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function

--- a/main.py
+++ b/main.py
@@ -378,5 +378,5 @@ def main():
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method("forkserver", force=True)  # Use "spawn" on Windows
+    # multiprocessing.set_start_method("forkserver", force=True)  # Use "spawn" on Windows
     main()

--- a/main.py
+++ b/main.py
@@ -28,343 +28,355 @@ from Tools import *
 import numpy as np
 import xarray
 import subprocess
+import multiprocessing
 
-# Print Python version
-print(sys.version)
 
-#
-# Read configuration file
-#
+def main():
+    # Print Python version
+    print(sys.version)
 
-if len(sys.argv) < 2:
-    dir_def = "DEF_Trunk/"
-else:
-    dir_def = sys.argv[1]
+    #
+    # Read configuration file
+    #
 
-sys.path.append(dir_def)
-import config
+    if len(sys.argv) < 2:
+        dir_def = "DEF_Trunk/"
+    else:
+        dir_def = sys.argv[1]
 
-# Define task
-itask = str(config.tasks)
+    sys.path.append(dir_def)
+    import config
 
-# Create Path to dir_def
-dir_def = Path(dir_def)
+    # Define task
+    itask = str(config.tasks)
 
-# Define result directory
-resultpath = Path(config.results_dir)
+    # Create Path to dir_def
+    dir_def = Path(dir_def)
 
-# Create results directory if it does not exist
-resultpath.mkdir(parents=True, exist_ok=True)
+    # Define result directory
+    resultpath = Path(config.results_dir)
 
-logfile = open(config.logfile, "w", buffering=1)
-check.display("Running task: %s" % itask, logfile)
-check.display("Results are stored at: " + str(resultpath), logfile)
+    # Create results directory if it does not exist
+    resultpath.mkdir(parents=True, exist_ok=True)
 
-# Write the configuration to the log file in the results directory
-with open(dir_def / "config.py", "r") as f:
-    check.display(f.read(), logfile)
+    logfile = open(config.logfile, "w", buffering=1)
+    check.display("Running task: %s" % itask, logfile)
+    check.display("Results are stored at: " + str(resultpath), logfile)
 
-check.display("DEF directory: " + str(dir_def), logfile)
+    # Write the configuration to the log file in the results directory
+    with open(dir_def / "config.py", "r") as f:
+        check.display(f.read(), logfile)
 
-# Read list of variables
-with open(dir_def / "varlist.json", "r") as f:
-    varlist = json.loads(f.read())
+    check.display("DEF directory: " + str(dir_def), logfile)
 
-# Load stored results or start from scratch
-if not config.start_from_scratch:
-    check.display("Read from previous results...", logfile)
-    packdata = xarray.load_dataset(resultpath / "packdata.nc")
-else:
-    check.display("MLacc start from scratch...", logfile)
-    # Initialize packaged data
-    packdata = readvar(varlist, config, logfile)
-    if os.path.exists(resultpath / "packdata.nc"):
-        refdata = xarray.load_dataset(resultpath / "packdata.nc")
-        assert (refdata == packdata).all()
-    packdata.to_netcdf(resultpath / "packdata.nc")
+    # Read list of variables
+    with open(dir_def / "varlist.json", "r") as f:
+        varlist = json.loads(f.read())
 
-# Define random seed
-iseed = config.random_seed
-random.seed(config.random_seed)
-np.random.seed(iseed)
-check.display("Random seed = %i" % iseed, logfile)
+    # Load stored results or start from scratch
+    if not config.start_from_scratch:
+        check.display("Read from previous results...", logfile)
+        packdata = xarray.load_dataset(resultpath / "packdata.nc")
+    else:
+        check.display("MLacc start from scratch...", logfile)
+        # Initialize packaged data
+        packdata = readvar(varlist, config, logfile)
+        if os.path.exists(resultpath / "packdata.nc"):
+            refdata = xarray.load_dataset(resultpath / "packdata.nc")
+            assert (refdata == packdata).all()
+        packdata.to_netcdf(resultpath / "packdata.nc")
 
-# Leave-one-out cross validation
-loocv = config.leave_one_out_cv
-
-# Check if parallel exists in config
-# Evaluates to True by default
-parallel = True
-if hasattr(config, "parallel"):
-    parallel = config.parallel
-
-# Create directory for model output if config has model_out (None by default)
-model_out_dir = None
-if hasattr(config, "model_out"):
-    model_out = config.model_out
-    if model_out:
-        model_out_dir = resultpath / "model_output"
-
-# Read take_unique setting in config
-take_unique = True
-if hasattr(config, "take_unique"):
-    take_unique = config.take_unique
-
-# Read the set_most_PFT_sites from the config (False by default)
-sel_most_PFT_sites = False
-if hasattr(config, "sel_most_PFT_sites"):
-    sel_most_PFT_sites = config.sel_most_PFT_sites
-
-old_cluster = True
-if hasattr(config, "old_cluster"):
-    old_cluster = config.old_cluster
-
-# if sel_most_PFT_sites is set to True and old_cluster is set to True, raise an error
-if sel_most_PFT_sites and not old_cluster:
-    raise ValueError(
-        "sel_most_PFT_sites and old_cluster cannot be set to True at the same time"
-    )
-
-# Task 1: Test clustering (optional)
-if "1" in itask:
-    dis_all = cluster.cluster_test(packdata, varlist, logfile)
-    # added line
-    np.random.seed(iseed)
-    dis_all.dump(resultpath / "dist_all.npy")
-    check.display(
-        "Test clustering done!\nResults have been stored as dist_all.npy", logfile
-    )
-
-    # Plot clustering results
-    fig, ax = plt.subplots()
-    lns = []
-    for ipft in range(dis_all.shape[1]):
-        lns += ax.plot(packdata.Ks, dis_all[:, ipft])
-    plt.legend(lns, varlist["clustering"]["pfts"], title="PFT")
-    ax.set_ylabel(
-        "Sum of squared distances of samples to\ntheir closest cluster center"
-    )
-    ax.set_xlabel("K-value (cluster size)")
-    fig.savefig(resultpath / "dist_all.png")
-    plt.close("all")
-    check.display(
-        "Test clustering results plotted!\nResults have been stored as dist_all.png",
-        logfile,
-    )
-    # Run test of reproducibility for the task if yes
-    if config.repro_test_task_1:
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task1.py", "--trunk", dir_def]
-        )
-        check.display(
-            "Task 1 reproducibility test results have been stored in tests_results.txt",
-            logfile,
-        )
-    check.display("Task 1: done", logfile)
-
-# Task 2: Clustering
-if "2" in itask:
-    np.random.seed(iseed)
-    K = config.kmeans_clusters
-    check.display("Kmean algorithm, K=%i" % K, logfile)
-    IDx, IDloc, IDsel = cluster.cluster_all(
-        packdata,
-        varlist,
-        K,
-        logfile,
-        take_unique,
-        sel_most_PFT_sites,
-        old_cluster,
-        iseed,
-    )
-    np.savetxt(resultpath / "IDx.txt", IDx, fmt="%.2f")
-    IDx.dump(resultpath / "IDx.npy")
-    IDloc.dump(resultpath / "IDloc.npy")
-    IDsel.dump(resultpath / "IDsel.npy")
-    check.display("Clustering done!\nResults have been stored as IDx.npy", logfile)
-
-    # Plot clustering results
-    kpfts = varlist["clustering"]["pfts"]
-    for ipft in range(len(kpfts)):
-        fig, ax = plt.subplots()
-        m = Basemap()
-        m.drawcoastlines()
-        m.scatter(IDloc[ipft][:, 1], IDloc[ipft][:, 0], s=10, marker="o", c="gray")
-        m.scatter(IDsel[ipft][:, 1], IDsel[ipft][:, 0], s=10, marker="o", c="red")
-        fig.savefig(resultpath / f"ClustRes_PFT{kpfts[ipft]}.png")
-        plt.close("all")
-    check.display(
-        "Clustering results plotted!\nResults have been stored as ClustRes_PFT*.png",
-        logfile,
-    )
-    # Run reproducibility tests for task 2
-    if config.repro_test_task_2:
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task2.py", "--trunk", dir_def]
-        )
-        check.display(
-            "Task 2 reproducibility test results have been stored in tests_results.txt",
-            logfile,
-        )
-    check.display("Task 2: done", logfile)
-
-# Task 3: Build aligned forcing and aligned restart files (optional)
-if "3" in itask:
-    check.check_file(resultpath / "IDx.npy", logfile)
-    IDx = np.load(resultpath / "IDx.npy", allow_pickle=True)
-    forcing.write(varlist, resultpath, IDx)
-    # Run test of reproducibility for task 3
-    if config.repro_test_task_3:
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task3.py", "--trunk", dir_def]
-        )
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task3_2.py", "--trunk", dir_def]
-        )
-        check.display(
-            "Task 3 reproducibility test results have been stored in tests_results.txt",
-            logfile,
-        )
-    check.display("Task 3: done", logfile)
-
-# Task 4: Machine learning and extrapolation
-if "4" in itask:
+    # Define random seed
+    iseed = config.random_seed
     random.seed(config.random_seed)
     np.random.seed(iseed)
+    check.display("Random seed = %i" % iseed, logfile)
 
-    # All predictor variable names (X)
-    var_pred_name1 = varlist["pred"]["allname"]
+    # Leave-one-out cross validation
+    loocv = config.leave_one_out_cv
 
-    # LAI and NPP predictor variable names (X)
-    var_pred_name2 = varlist["pred"]["allname_pft"]
+    # Check if parallel exists in config
+    # Evaluates to True by default
+    parallel = True
+    if hasattr(config, "parallel"):
+        parallel = config.parallel
 
-    # All feature names (X)
-    var_pred_name = var_pred_name1 + var_pred_name2
+    # Create directory for model output if config has model_out (None by default)
+    model_out_dir = None
+    if hasattr(config, "model_out"):
+        model_out = config.model_out
+        if model_out:
+            model_out_dir = resultpath / "model_output"
 
-    # Response variable names (Y)
-    Yvar = varlist["resp"]["variables"]
+    # Read take_unique setting in config
+    take_unique = True
+    if hasattr(config, "take_unique"):
+        take_unique = config.take_unique
 
-    check.check_file(resultpath / "IDx.npy", logfile)
-    IDx = np.load(resultpath / "IDx.npy", allow_pickle=True)
+    # Read the set_most_PFT_sites from the config (False by default)
+    sel_most_PFT_sites = False
+    if hasattr(config, "sel_most_PFT_sites"):
+        sel_most_PFT_sites = config.sel_most_PFT_sites
 
-    packdata.attrs.update(
-        Nv_nopft=len(var_pred_name1),
-        Nv_total=len(var_pred_name),
-        var_pred_name=var_pred_name,
-        Nlat=np.trunc((90 - IDx[:, 0]) / packdata.lat_reso).astype(int),
-        Nlon=np.trunc((180 + IDx[:, 1]) / packdata.lon_reso).astype(int),
-    )
-    labx = ["Y"] + list(packdata.data_vars) + ["pft"]
-    # labx = ["Y"] + var_pred_name + ["pft"]
-    # Copy the restart file to be modified
-    targetfile = (
-        varlist["resp"]["targetfile"]
-        if "targetfile" in varlist["resp"]
-        else varlist["resp"]["sourcefile"]
-    )
-    restfile = resultpath / targetfile.split("/")[-1]
-    os.system("cp -f %s %s" % (targetfile, restfile))
-    # Add rights to manipulate file:
-    os.chmod(restfile, 0o644)
+    old_cluster = True
+    if hasattr(config, "old_cluster"):
+        old_cluster = config.old_cluster
 
-    for alg in config.algorithms:
-        result = []
-        for ipool in Yvar.keys():
-            check.display("processing %s..." % ipool, logfile)
-            res_df = ml.ml_loop(
-                packdata,
-                ipool,
-                logfile,
-                varlist,
-                labx,
-                config,
-                restfile,
-                alg,
-                parallel,
-                model_out_dir,
-                seed=iseed,
-            )
-            result.append(res_df)
-            # Debugging
-            # break
-
-        res_df = pd.concat(result, keys=Yvar.keys(), names=["comp"])
-        scores = res_df.mean()[["R2", "slope"]].to_frame().T
-        scores = scores.assign(alg=alg).set_index("alg")
-        path = resultpath / "ML_log.csv"
-        scores.to_csv(path, mode="a", header=not path.exists())
-
-        res_path = resultpath / "MLacc_results.csv"
-        # if res_path.exists():
-        #     ref_df = pd.read_csv(res_path, index_col=[0, 1, 2])
-        #     perf_diff = res_df["slope"] - ref_df["slope"]
-        #     if perf_diff.mean() > 0 and (perf_diff > 0).mean() > 0.5:
-        #         res_df.to_csv(res_path)
-        #     else:
-        #         print("Degraded performance:", perf_diff.mean(), (perf_diff > 0).mean())
-        # else:
-        res_df.to_csv(res_path)
-
-    # Additional variables need to be handled in the restart files which are not state variables of ORCHIDEE
-    if "additional_vars" not in varlist["resp"]:
-        # Handle the case where 'additional_vars' is not present
-        print("We only modify true state variables of ORCHIDEE")
-    else:
-        additional_vars = varlist["resp"]["additional_vars"]
-
-        for var in additional_vars:
-            check.display("processing %s..." % var, logfile)
-            restnc = Dataset(restfile, "a")
-            # All variables derive from npp longterm prediction
-            restvar = restnc["npp_longterm"]
-            restvar1 = restnc[var]
-
-            if var == "gpp_week" or var == "maxgppweek_lastyear" or var == "gpp_daily":
-                tmpvar = restvar[:] * 2.0
-            else:
-                tmpvar = restvar[:]
-
-            restvar1[:] = tmpvar
-            restnc.close()
-        # Run reproducibility tests for task 4
-    if config.repro_test_task_4:
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task4.py", "--trunk", dir_def]
+    # if sel_most_PFT_sites is set to True and old_cluster is set to True, raise an error
+    if sel_most_PFT_sites and not old_cluster:
+        raise ValueError(
+            "sel_most_PFT_sites and old_cluster cannot be set to True at the same time"
         )
-        subprocess.run(
-            ["python", "-m", "pytest", "tests/test_task4_2.py", "--trunk", dir_def]
-        )
+
+    # Task 1: Test clustering (optional)
+    if "1" in itask:
+        dis_all = cluster.cluster_test(packdata, varlist, logfile)
+        # added line
+        np.random.seed(iseed)
+        dis_all.dump(resultpath / "dist_all.npy")
         check.display(
-            "Task 4 reproducibility test results have been stored in tests_results.txt",
+            "Test clustering done!\nResults have been stored as dist_all.npy", logfile
+        )
+
+        # Plot clustering results
+        fig, ax = plt.subplots()
+        lns = []
+        for ipft in range(dis_all.shape[1]):
+            lns += ax.plot(packdata.Ks, dis_all[:, ipft])
+        plt.legend(lns, varlist["clustering"]["pfts"], title="PFT")
+        ax.set_ylabel(
+            "Sum of squared distances of samples to\ntheir closest cluster center"
+        )
+        ax.set_xlabel("K-value (cluster size)")
+        fig.savefig(resultpath / "dist_all.png")
+        plt.close("all")
+        check.display(
+            "Test clustering results plotted!\nResults have been stored as dist_all.png",
             logfile,
         )
-    check.display("Task 4: done", logfile)
-
-# Task 5: Evaluation
-if "5" in itask:
-    Yvar = varlist["resp"]["variables"]
-    for ipool in Yvar.keys():
-        # if ipool!="litter":continue
-        subLabel = varlist["resp"]["sub_item"]
-
-        # if varlist["resp"]["pool_name_"+ipool] does not exist, use ipool as subpool_name
-        if "pool_name_" + ipool not in varlist["resp"]:
-            subpool_name = [ipool]
-            subLabel = ["None"]
-        else:
-            subpool_name = varlist["resp"]["pool_name_" + ipool]
-        npfts = varlist["resp"]["npfts"]
-        pp = varlist["resp"]["dim"][ipool]
-        sect_n = varlist["resp"]["sect_n"][ipool]
-        if pp[0] == "pft":
-            dims = np.array([0, 1])
-        else:
-            dims = np.array([1, 0])
-        eval_plot_un.plot_metric(resultpath, npfts, ipool, subLabel, subpool_name)
-        if loocv:
-            eval_plot_loocv_un.plot_metric(
-                resultpath, npfts, ipool, subLabel, dims, sect_n, subpool_name
+        # Run test of reproducibility for the task if yes
+        if config.repro_test_task_1:
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task1.py", "--trunk", dir_def]
             )
+            check.display(
+                "Task 1 reproducibility test results have been stored in tests_results.txt",
+                logfile,
+            )
+        check.display("Task 1: done", logfile)
+
+    # Task 2: Clustering
+    if "2" in itask:
+        np.random.seed(iseed)
+        K = config.kmeans_clusters
+        check.display("Kmean algorithm, K=%i" % K, logfile)
+        IDx, IDloc, IDsel = cluster.cluster_all(
+            packdata,
+            varlist,
+            K,
+            logfile,
+            take_unique,
+            sel_most_PFT_sites,
+            old_cluster,
+            iseed,
+        )
+        np.savetxt(resultpath / "IDx.txt", IDx, fmt="%.2f")
+        IDx.dump(resultpath / "IDx.npy")
+        IDloc.dump(resultpath / "IDloc.npy")
+        IDsel.dump(resultpath / "IDsel.npy")
+        check.display("Clustering done!\nResults have been stored as IDx.npy", logfile)
+
+        # Plot clustering results
+        kpfts = varlist["clustering"]["pfts"]
+        for ipft in range(len(kpfts)):
+            fig, ax = plt.subplots()
+            m = Basemap()
+            m.drawcoastlines()
+            m.scatter(IDloc[ipft][:, 1], IDloc[ipft][:, 0], s=10, marker="o", c="gray")
+            m.scatter(IDsel[ipft][:, 1], IDsel[ipft][:, 0], s=10, marker="o", c="red")
+            fig.savefig(resultpath / f"ClustRes_PFT{kpfts[ipft]}.png")
+            plt.close("all")
+        check.display(
+            "Clustering results plotted!\nResults have been stored as ClustRes_PFT*.png",
+            logfile,
+        )
+        # Run reproducibility tests for task 2
+        if config.repro_test_task_2:
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task2.py", "--trunk", dir_def]
+            )
+            check.display(
+                "Task 2 reproducibility test results have been stored in tests_results.txt",
+                logfile,
+            )
+        check.display("Task 2: done", logfile)
+
+    # Task 3: Build aligned forcing and aligned restart files (optional)
+    if "3" in itask:
+        check.check_file(resultpath / "IDx.npy", logfile)
+        IDx = np.load(resultpath / "IDx.npy", allow_pickle=True)
+        forcing.write(varlist, resultpath, IDx)
+        # Run test of reproducibility for task 3
+        if config.repro_test_task_3:
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task3.py", "--trunk", dir_def]
+            )
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task3_2.py", "--trunk", dir_def]
+            )
+            check.display(
+                "Task 3 reproducibility test results have been stored in tests_results.txt",
+                logfile,
+            )
+        check.display("Task 3: done", logfile)
+
+    # Task 4: Machine learning and extrapolation
+    if "4" in itask:
+        random.seed(config.random_seed)
+        np.random.seed(iseed)
+
+        # All predictor variable names (X)
+        var_pred_name1 = varlist["pred"]["allname"]
+
+        # LAI and NPP predictor variable names (X)
+        var_pred_name2 = varlist["pred"]["allname_pft"]
+
+        # All feature names (X)
+        var_pred_name = var_pred_name1 + var_pred_name2
+
+        # Response variable names (Y)
+        Yvar = varlist["resp"]["variables"]
+
+        check.check_file(resultpath / "IDx.npy", logfile)
+        IDx = np.load(resultpath / "IDx.npy", allow_pickle=True)
+
+        packdata.attrs.update(
+            Nv_nopft=len(var_pred_name1),
+            Nv_total=len(var_pred_name),
+            var_pred_name=var_pred_name,
+            Nlat=np.trunc((90 - IDx[:, 0]) / packdata.lat_reso).astype(int),
+            Nlon=np.trunc((180 + IDx[:, 1]) / packdata.lon_reso).astype(int),
+        )
+        labx = ["Y"] + list(packdata.data_vars) + ["pft"]
+        # labx = ["Y"] + var_pred_name + ["pft"]
+        # Copy the restart file to be modified
+        targetfile = (
+            varlist["resp"]["targetfile"]
+            if "targetfile" in varlist["resp"]
+            else varlist["resp"]["sourcefile"]
+        )
+        restfile = resultpath / targetfile.split("/")[-1]
+        os.system("cp -f %s %s" % (targetfile, restfile))
+        # Add rights to manipulate file:
+        os.chmod(restfile, 0o644)
+
+        for alg in config.algorithms:
+            result = []
+            for ipool in Yvar.keys():
+                check.display("processing %s..." % ipool, logfile)
+                res_df = ml.ml_loop(
+                    packdata,
+                    ipool,
+                    logfile,
+                    varlist,
+                    labx,
+                    config,
+                    restfile,
+                    alg,
+                    parallel,
+                    model_out_dir,
+                    seed=iseed,
+                )
+                result.append(res_df)
+                # Debugging
+                # break
+
+            res_df = pd.concat(result, keys=Yvar.keys(), names=["comp"])
+            scores = res_df.mean()[["R2", "slope"]].to_frame().T
+            scores = scores.assign(alg=alg).set_index("alg")
+            path = resultpath / "ML_log.csv"
+            scores.to_csv(path, mode="a", header=not path.exists())
+
+            res_path = resultpath / "MLacc_results.csv"
+            # if res_path.exists():
+            #     ref_df = pd.read_csv(res_path, index_col=[0, 1, 2])
+            #     perf_diff = res_df["slope"] - ref_df["slope"]
+            #     if perf_diff.mean() > 0 and (perf_diff > 0).mean() > 0.5:
+            #         res_df.to_csv(res_path)
+            #     else:
+            #         print("Degraded performance:", perf_diff.mean(), (perf_diff > 0).mean())
+            # else:
+            res_df.to_csv(res_path)
+
+        # Additional variables need to be handled in the restart files which are not state variables of ORCHIDEE
+        if "additional_vars" not in varlist["resp"]:
+            # Handle the case where 'additional_vars' is not present
+            print("We only modify true state variables of ORCHIDEE")
         else:
-            continue
-    check.display("Task 5: done", logfile)
+            additional_vars = varlist["resp"]["additional_vars"]
+
+            for var in additional_vars:
+                check.display("processing %s..." % var, logfile)
+                restnc = Dataset(restfile, "a")
+                # All variables derive from npp longterm prediction
+                restvar = restnc["npp_longterm"]
+                restvar1 = restnc[var]
+
+                if (
+                    var == "gpp_week"
+                    or var == "maxgppweek_lastyear"
+                    or var == "gpp_daily"
+                ):
+                    tmpvar = restvar[:] * 2.0
+                else:
+                    tmpvar = restvar[:]
+
+                restvar1[:] = tmpvar
+                restnc.close()
+            # Run reproducibility tests for task 4
+        if config.repro_test_task_4:
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task4.py", "--trunk", dir_def]
+            )
+            subprocess.run(
+                ["python", "-m", "pytest", "tests/test_task4_2.py", "--trunk", dir_def]
+            )
+            check.display(
+                "Task 4 reproducibility test results have been stored in tests_results.txt",
+                logfile,
+            )
+        check.display("Task 4: done", logfile)
+
+    # Task 5: Evaluation
+    if "5" in itask:
+        Yvar = varlist["resp"]["variables"]
+        for ipool in Yvar.keys():
+            # if ipool!="litter":continue
+            subLabel = varlist["resp"]["sub_item"]
+
+            # if varlist["resp"]["pool_name_"+ipool] does not exist, use ipool as subpool_name
+            if "pool_name_" + ipool not in varlist["resp"]:
+                subpool_name = [ipool]
+                subLabel = ["None"]
+            else:
+                subpool_name = varlist["resp"]["pool_name_" + ipool]
+            npfts = varlist["resp"]["npfts"]
+            pp = varlist["resp"]["dim"][ipool]
+            sect_n = varlist["resp"]["sect_n"][ipool]
+            if pp[0] == "pft":
+                dims = np.array([0, 1])
+            else:
+                dims = np.array([1, 0])
+            eval_plot_un.plot_metric(resultpath, npfts, ipool, subLabel, subpool_name)
+            if loocv:
+                eval_plot_loocv_un.plot_metric(
+                    resultpath, npfts, ipool, subLabel, dims, sect_n, subpool_name
+                )
+            else:
+                continue
+        check.display("Task 5: done", logfile)
+
+
+if __name__ == "__main__":
+    multiprocessing.set_start_method("forkserver", force=True)  # Use "spawn" on Windows
+    main()

--- a/main.py
+++ b/main.py
@@ -288,8 +288,6 @@ def main():
                     seed=iseed,
                 )
                 result.append(res_df)
-                # Debugging
-                # break
 
             res_df = pd.concat(result, keys=Yvar.keys(), names=["comp"])
             scores = res_df.mean()[["R2", "slope"]].to_frame().T

--- a/main.py
+++ b/main.py
@@ -378,5 +378,5 @@ def main():
 
 
 if __name__ == "__main__":
-    # multiprocessing.set_start_method("forkserver", force=True)  # Use "spawn" on Windows
+    multiprocessing.set_start_method("forkserver", force=True)  # Use "spawn" on Windows
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-basemap==1.3.6
+basemap==1.4.1
 imblearn==0.0
 matplotlib==3.5.2
 netCDF4==1.6.2

--- a/tests/test_task4_2.py
+++ b/tests/test_task4_2.py
@@ -6,7 +6,8 @@ import os
 @pytest.mark.parametrize(
     "filename", ["SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc"]
 )
-def test_compare_nc_files(reference_path, test_path, filename):
-    compare_nc_files(
-        os.path.join(reference_path, filename), os.path.join(test_path, filename)
-    )
+def test_compare_nc_files_should_differ(reference_path, test_path, filename):
+    with pytest.raises(AssertionError):
+        compare_nc_files(
+            os.path.join(reference_path, filename), os.path.join(test_path, filename)
+        )

--- a/tests/test_task5.py
+++ b/tests/test_task5.py
@@ -27,7 +27,7 @@ def test_visualisation():
 
     resultpath = Path("tests/data/")
 
-    with open(resultpath / "varlist.json", "r") as f:
+    with open("DEF_Trunk/varlist.json", "r") as f:
         varlist = json.loads(f.read())
 
     Yvar = varlist["resp"]["variables"]


### PR DESCRIPTION
This PR fixes issue #102 and parallelism generally. It also fixes issue #107 i.e. the checkpoint/restart file was not being modified. The latter regression was introduced as a result of process based parallelism which prevents pointers to file handles from being passed around within parallel blocks. 

### Netcdf fix
Has been merged from #102. It moves the write after the processing by carrying around temporary variables. 
Previously the `extract_data` function had written to the `restvar` object which was a pointer to a variable within the checkpoint file `restvar = restnc[varname]`. We write to the file `GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc`.

- function chain: `ml_loop` -> `mlmap_multidim` -> `extrapolate_globally`
- `extrapolate_globally` now returns two additional variables `Pred_Y_out`, and `idx`.
- We now output a 4 element tuple from mlmap_multidim containing `(evaluate(..) : Dict, Pred_Y_out,
            idx,
            varname)`
- These are concatenated and the restart file is updated in `ml_loop` for each pool separately (Carbon, Biomass, Litter...)



### Parallel fix
The ProcessPoolExecutor hangs at Step 4. This arose because of the recent change to process parallelism from thread parallelism. 
The fix does the following:

- Adds`if __name__ == "__main__"` to `main.py`. This is good practice anyway as it prevents the execution of code due to import. This is unlikely to happen in this case, however.
  - The above addition also prevents infinite recursion within github actions. 
- It also relies on the setting `multiprocessing.set_start_method("forkserver", force=True)` at the main call, instead of just `fork`. `forkserver` does not inherit threads, preventing deadlocks. This seems to suggest that some threads are lingering and need to be destroyed. In general, however, forkserver seems to be safer in CI environments. 


With parallel execution the CI for DEF_Trunk now runs in 6m. See this successful [run](https://github.com/CALIPSO-project/SPINacc/actions/runs/13272801072).

### Process Parallelisation

The table shows the speedup obtained by using process parallelism.

| Configuration       | Trunk        | CNP2         |
|---------------------|--------------|--------------|
| Baseline Parallel   | 30s (10GB memory) | 1m15s       |
| Baseline Serial     | 5m25s        | 33m46s       |
| Speed Up (factor)   | 11x          | 27x          |
