### PR TITLE
Fix: adapt setup script to new folder script with DEF folders in jobs

### DIFF
--- a/setup-data.sh
+++ b/setup-data.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 if [ -n "$1" ]; then
   DEF_TRUNK_PATH="$1"
 else
-  DEF_TRUNK_PATH="DEF_Trunk"
+  DEF_TRUNK_PATH="jobs/DEF_Trunk"
 fi
 
 # Resolve the full path for varlist_json


### PR DESCRIPTION
Bugfix for the setup script to deal with the new folder structure in which DEF folders are within the folder jobs