### PR TITLE
Developing the use of (pseudo) unstructured grid for step 3 and step 4,

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It includes:
 * `ORCHIDEE_forcing_data` - Explained in [jobs/DEF_Trunk/varlist-explained.md](jobs/DEF_Trunk/varlist_explained.md)
 * `reference` data - necessary to run the reproducibility checks (Now OUTDATED see [Reproducibility tests](#set-up-baseline-reproducibility-checks)).
 
-The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `jobs/DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
+The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `jobs/DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (i.e. ORCHIDEE climate forcing files) (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data is stored on obelix cluster on orchideeshare will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
 
 To ensure the script works without error, set the `MYTWODEG` and `MYFORCING` paths appropriately. The `MYFORCING` path points to where you want the forcing data to be extracted to. The default location is `ORCHIDEE_forcing_data` in the project root.
 
@@ -173,7 +173,7 @@ The following settings can change the performance of SPINacc:
 * `old_cluster` (default - `True`): If `True`, the clustering step will use the old clustering method - i.e. Randomly samples Nc examples or takes all samples if number of samples is less than Nc. If `old_cluster = False`, the new clustering method will take the max(Nc, 20% subset of locations).
 * `sel_most_PFT_sites` (default - `False`): If `True` and `old_cluster = False`, it will preferentially select samples that contain more PFTs using the 20% rule detailed previously.  If `old_cluster = True` and `sel_most_PFT_sites = True`, an error is thrown.
 
-We recommend always setting `parallel = True` in `config.py` to speed up the execution of SPINacc. The serial and parallel execution gives exactly the same results, however it may sometimes be useful to turn this off for debugging purposes.
+We recommend always setting `parallel = True` in `config.py` to speed up the execution of SPINacc. The serial and parallel execution gives exactly the same results, however it may sometimes be useful to turn this off for debugging purposes. If parallel execution is used, request the respective number of processors in the `jobs/obelix/job` by adding `#PBS -l ncpus=4`
 
 
 ### Obtaining best performance.
@@ -199,9 +199,9 @@ old_cluster = False
 
 If you are already using the obelix supercomputer is likely that SPINacc will work without much adjustment to the `varlist.json` file.
 
-Jobs can be submitted using the provided pbs scripts, [job](job):
-* In __job__ : __setenv dirpython '/your/path/to/SPINacc/'__ and __setenv dirdef 'DEF_Trunk/'__
-* Then launch your first job using  **qsub -q short job**, for task 1
+Jobs can be submitted using the provided pbs scripts, [jobs/obelix/job](jobs/obelix/job):
+* In __job__ : __setenv dirpython '/your/path/to/SPINacc/'__ and __setenv dirdef 'jobs/DEF_Trunk/'__
+* Then launch your first job using  **qsub -q short jobs/obelix/job**, for task 1
 * For tasks 3 and 4, it is better to use **qsub -q medium job**
 
 ## Overview of the individual tasks

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The following settings can change the performance of SPINacc:
 * `old_cluster` (default - `True`): If `True`, the clustering step will use the old clustering method - i.e. Randomly samples Nc examples or takes all samples if number of samples is less than Nc. If `old_cluster = False`, the new clustering method will take the max(Nc, 20% subset of locations).
 * `sel_most_PFT_sites` (default - `False`): If `True` and `old_cluster = False`, it will preferentially select samples that contain more PFTs using the 20% rule detailed previously.  If `old_cluster = True` and `sel_most_PFT_sites = True`, an error is thrown.
 
-We recommend always setting `parallel = True` in `config.py` to speed up the execution of SPINacc. The serial and parallel execution gives exactly the same results, however it may sometimes be useful to turn this off for debugging purposes. If parallel execution is used, request the respective number of processors in the `jobs/obelix/job` by adding `#PBS -l ncpus=4`
+We recommend always setting `parallel = True` in `config.py` to speed up the execution of SPINacc. The serial and parallel execution gives exactly the same results, however it may sometimes be useful to turn this off for debugging purposes. If parallel execution is used, request the respective number of processors in the `jobs/obelix/job` script by activating (uncommenting, i.e. changing `##PBS -l ncpus=4` to `#PBS -l ncpus=4`) or adding the appropriate `#PBS -l ncpus=<N>` directive.
 
 
 ### Obtaining best performance.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It includes:
 * `ORCHIDEE_forcing_data` - Explained in [jobs/DEF_Trunk/varlist-explained.md](jobs/DEF_Trunk/varlist_explained.md)
 * `reference` data - necessary to run the reproducibility checks (Now OUTDATED see [Reproducibility tests](#set-up-baseline-reproducibility-checks)).
 
-The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `jobs/DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (i.e. ORCHIDEE climate forcing files) (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data is stored on obelix cluster on orchideeshare will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
+The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `jobs/DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (i.e. ORCHIDEE climate forcing files) (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data is stored on the Obelix cluster (orchideeshare) and will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
 
 To ensure the script works without error, set the `MYTWODEG` and `MYFORCING` paths appropriately. The `MYFORCING` path points to where you want the forcing data to be extracted to. The default location is `ORCHIDEE_forcing_data` in the project root.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation of aims, concepts, workflows are described in [Sun et al (2022)](h
 ## Contents
 The SPINacc package includes:
 * `main.py` - The main python module that steers the execution of SPINacc.
-* `DEF_*/`  - Directories with configuration files for each of the supported ORCHIDEE versions.
+* `jobs/*`  - Directories with configuration files for each of the supported ORCHIDEE versions.
     * `config.py` - Settings to configure the machine learning performance.
     * `varlist.json` - Configure paths to ORCHIDEE forcing output and climate data.
     * `varlist-explained.md` - Documentation of data sources used in SPINacc.
@@ -49,21 +49,21 @@ Here are the steps to launch SPINacc end-to-end, including the optional tests.
 These instructions are applicable regardless of the system you work on, however if you already have access to datasets on the Obelix supercomputer it is likely that SPINacc will run with minimal modification (see [Running on Obelix](#running-on-the-obelix-supercomputer) if you believe this is the case). We provide a ZENODO repository that contains forcing data [here](https://doi.org/10.5281/zenodo.10514124) as well as reference output for reproducibility testing.
 
 It includes:
-* `ORCHIDEE_forcing_data` - Explained in [DEF_Trunk/varlist-explained.md](DEF_Trunk/varlist_explained.md)
+* `ORCHIDEE_forcing_data` - Explained in [jobs/DEF_Trunk/varlist-explained.md](jobs/DEF_Trunk/varlist_explained.md)
 * `reference` data - necessary to run the reproducibility checks (Now OUTDATED see [Reproducibility tests](#set-up-baseline-reproducibility-checks)).
 
-The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
+The [setup-data.sh](setup-data.sh) script has been provided to automate the download of the associated ZENODO repository and set paths to the forcing data and climate data in `jobs/DEF_Trunk/varlist.json`. The ZENODO repository does not include climate data files (variable name `twodeg`, without this, initialisation will fail and SPINacc will be unable to proceed). The climate data will be made available upon request to Daniel Goll (https://www.lsce.ipsl.fr/en/pisp/daniel-goll/).
 
 To ensure the script works without error, set the `MYTWODEG` and `MYFORCING` paths appropriately. The `MYFORCING` path points to where you want the forcing data to be extracted to. The default location is `ORCHIDEE_forcing_data` in the project root.
 
-The script runs the `sed` command to replace all occurences of `/home/surface5/vbastri/` with the downloaded and extracted `ORCHIDEE_forcing_data` in `/your/path/to/forcing/vlad_files/vlad_files/` in `DEF_Trunk/varlist.json`. This can be done manually if desired.
+The script runs the `sed` command to replace all occurences of `/home/surface5/vbastri/` with the downloaded and extracted `ORCHIDEE_forcing_data` in `/your/path/to/forcing/vlad_files/vlad_files/` in `jobs/DEF_Trunk/varlist.json`. This can be done manually if desired.
 
 
 #### Running SPINacc
 
 These instructions are designed to get up and running with SPINacc quickly and then run the accompanying tests. See the section below on [Obtaining 'best' performance](#obtaining-best-performance) for a more detailed overview of how to optimally adjust ML performance.
 
-1. In `DEF_Trunk/config.py` modify the `results_dir` variable to point to a different path if desired. To run SPINacc from end-to-end, ensure that the steps are set as follows:
+1. In `jobs/DEF_Trunk/config.py` modify the `results_dir` variable to point to a different path if desired. To run SPINacc from end-to-end, ensure that the steps are set as follows:
     ```
     tasks = [
         1,
@@ -81,9 +81,9 @@ These instructions are designed to get up and running with SPINacc quickly and t
 
 2. Then run:
     ```
-    python main.py DEF_Trunk/
+    python main.py jobs/DEF_Trunk/
     ```
-    By default, `main.py` will look for the `DEF_Trunk` directory. SPINacc supports passing other configuration / job directories as arguments to `main.py` (i.e. `python main.py DEF_CNP2/`. It is helpful to create copies of the default configurations and then modify for your own purposes to avoid continuously stashing work. )
+    By default, `main.py` will look for the `jobs/DEF_Trunk` directory. SPINacc supports passing other configuration / job directories as arguments to `main.py` (i.e. `python main.py jobs/DEF_CNP2/`. It is helpful to create copies of the default configurations and then modify for your own purposes to avoid continuously stashing work. )
 
     Results are located in your output directory under `MLacc_results.csv`. Visualisations of R2, Slope and dNRMSE are can be found each component in `Eval_all_biomassCpool.png`, `Eval_all_litterCpool.png` and `Eval_all_somCpool.png`.
 
@@ -100,21 +100,21 @@ These tests are useful to ensure that regressions have not been unexpectedly int
 
     `git clone https://github.com/ma595/SPINacc-results`
 
-2. In `DEF_Trunk/config.py` set the `reference_dir` variable to point to `SPINacc-results/Trunk`.
+2. In `jobs/DEF_Trunk/config.py` set the `reference_dir` variable to point to `SPINacc-results/Trunk`.
 
-3. \[Optional\] To execute the reproducibility checks at runtime ensure that `True` values are set in all relevant steps in `DEF_Trunk/config.py`.
+3. \[Optional\] To execute the reproducibility checks at runtime ensure that `True` values are set in all relevant steps in `jobs/DEF_Trunk/config.py`.
 
 4. Alternatively, the tests can be executed after the successful completion of a run by doing the following:
 
     ```
-    pytest --trunk=DEF_Trunk/ -v --capture=sys
+    pytest --trunk=jobs/DEF_Trunk/ -v --capture=sys
     ```
     Above it is possible to point to different output directories with the `--trunk` flag.
 
     To run a single test do:
 
     ```
-    pytest --trunk=DEF_Trunk -v --capture=sys ./tests/test_task4.py
+    pytest --trunk=jobs/DEF_Trunk -v --capture=sys ./tests/test_task4.py
     ```
     The command line arguments `-v` and `--capture=sys` makes test output more visible to users.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ If you are already using the obelix supercomputer is likely that SPINacc will wo
 Jobs can be submitted using the provided pbs scripts, [jobs/obelix/job](jobs/obelix/job):
 * In __job__ : __setenv dirpython '/your/path/to/SPINacc/'__ and __setenv dirdef 'jobs/DEF_Trunk/'__
 * Then launch your first job using  **qsub -q short jobs/obelix/job**, for task 1
-* For tasks 3 and 4, it is better to use **qsub -q medium job**
+* For tasks 3 and 4, it is better to use **qsub -q medium jobs/obelix/job**
 
 ## Overview of the individual tasks
 

--- a/Tools/cluster.py
+++ b/Tools/cluster.py
@@ -210,8 +210,10 @@ def cluster_all(
     IDx = np.concatenate([adict["PFT%itrainingID" % ii] for ii in kpfts])
 
     # 6. If take_unique is False, we are equivalent to the original implementation
-    if take_unique:
-        IDx = np.unique(IDx, axis=0)
+    #if take_unique:
+    #    IDx = np.unique(IDx, axis=0)
+    IDx = np.unique(IDx, axis=0)
+
     IDloc = np.array([adict["PFT%iClusD" % ii]["clus_01_loc"] for ii in kpfts])
     IDsel = np.array([adict["PFT%iClusD" % ii]["clus_01_loc_select"] for ii in kpfts])
     return IDx, IDloc, IDsel

--- a/Tools/cluster.py
+++ b/Tools/cluster.py
@@ -157,9 +157,7 @@ def cluster_test(packdata, varlist, logfile):
     return dis_all
 
 
-def cluster_all(
-    packdata, varlist, KK, logfile, sel_most_PFTs, old_cluster, seed
-):
+def cluster_all(packdata, varlist, KK, logfile, sel_most_PFTs, old_cluster, seed):
     """
     Perform clustering for all specified PFTs with a chosen K value.
 

--- a/Tools/cluster.py
+++ b/Tools/cluster.py
@@ -158,7 +158,7 @@ def cluster_test(packdata, varlist, logfile):
 
 
 def cluster_all(
-    packdata, varlist, KK, logfile, take_unique, sel_most_PFTs, old_cluster, seed
+    packdata, varlist, KK, logfile, sel_most_PFTs, old_cluster, seed
 ):
     """
     Perform clustering for all specified PFTs with a chosen K value.
@@ -208,10 +208,7 @@ def cluster_all(
 
     # 5. Output the ID
     IDx = np.concatenate([adict["PFT%itrainingID" % ii] for ii in kpfts])
-
-    # 6. If take_unique is False, we are equivalent to the original implementation
-    #if take_unique:
-    #    IDx = np.unique(IDx, axis=0)
+    # ensure unique locations
     IDx = np.unique(IDx, axis=0)
 
     IDloc = np.array([adict["PFT%iClusD" % ii]["clus_01_loc"] for ii in kpfts])

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -3,7 +3,7 @@ from Tools import *
 
 def write(varlist, resultpath, IDx):
     # select mode to build forcing and restart files
-    # possible modes: compressed, regular, aligned
+    # possible modes: unstructured, regular
     # mode = "unstructured"
     mode = varlist["resp"]["format"]
 

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -291,7 +291,7 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            ncout = Dataset(resultpath / f"forcing_aligned_{year}.nc", "w")
+            taset(resultpath / os.path.split(path)[-1], "w")
 
             for dim in nc.dimensions:
                 if dim == "land":
@@ -392,7 +392,7 @@ def write(varlist, resultpath, IDx):
         for path in varlist["restart"]:
             print("Building aligned restart file for", path)
             nc = Dataset(path)
-            ncout = Dataset(resultpath + os.path.split(path)[-1], "w")
+            ncout = Dataset(resultpath / os.path.split(path)[-1], "w")
             for dim in nc.dimensions:
                 newsize = (
                     len(plat)

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -3,7 +3,8 @@ from Tools import *
 def write(varlist, resultpath, IDx):
     # select mode to build forcing and restart files
     # possible modes: compressed, regular, aligned
-    mode = "unstructured"
+    #mode = "unstructured"
+    mode = varlist["resp"]["mode"]
 
     # define indices of selected pixels using the first forcing year
     nc = Dataset(

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -1,9 +1,10 @@
 from Tools import *
 
+
 def write(varlist, resultpath, IDx):
     # select mode to build forcing and restart files
     # possible modes: compressed, regular, aligned
-    #mode = "unstructured"
+    # mode = "unstructured"
     mode = varlist["resp"]["format"]
 
     # define indices of selected pixels using the first forcing year
@@ -73,60 +74,67 @@ def write(varlist, resultpath, IDx):
             + str(varlist["climate"]["year_start"])
             + ".nc"
         )
-    
-        lat = nc_first.variables.get("lat", nc_first.variables.get("latitude", nc_first.variables.get("nav_lat")))[:]
-        lon = nc_first.variables.get("lon", nc_first.variables.get("longitude", nc_first.variables.get("nav_lon")))[:]
+
+        lat = nc_first.variables.get(
+            "lat", nc_first.variables.get("latitude", nc_first.variables.get("nav_lat"))
+        )[:]
+        lon = nc_first.variables.get(
+            "lon",
+            nc_first.variables.get("longitude", nc_first.variables.get("nav_lon")),
+        )[:]
         if len(lat.shape) > 1:
             lat = lat[:, 0]
         if len(lon.shape) > 1:
             lon = lon[0, :]
         land = nc_first.variables["land"][:] if "land" in nc_first.dimensions else None
-    
+
         # Build unique pixel indices
         unique_pixels = set()
         ilats, ilons, ilands, xlands = [], [], [], []
         for xlat, xlon in IDx:
             ilat = np.argmin(np.abs(lat - xlat))
             ilon = np.argmin(np.abs(lon - xlon))
-    
+
             if (ilat, ilon) in unique_pixels:
                 continue
             unique_pixels.add((ilat, ilon))
-    
+
             xland = ilat * len(lon) + ilon + 1
             iland = np.where(land == xland)[0][0] if land is not None else None
-    
+
             ilats.append(ilat)
             ilons.append(ilon)
             ilands.append(iland)
             xlands.append(xland)
-    
+
         ilats = np.array(ilats)
         ilons = np.array(ilons)
         ilands = np.array(ilands)
         xlands = np.array(xlands)
         nc_first.close()
-    
+
         n_cells = len(ilats)  # number of unique pixels
-    
+
         # Process each year
-        for year in range(varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1):
+        for year in range(
+            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
+        ):
             print(f"Building unstructured forcing for year {year}")
-    
+
             nc = Dataset(
                 varlist["climate"]["sourcepath"]
                 + varlist["climate"]["filename"]
                 + str(year)
                 + ".nc"
             )
-    
+
             ncout = Dataset(str(resultpath / f"forcing_unstructured_{year}.nc"), "w")
-    
+
             # Define dimensions
             ncout.createDimension("tstep", None)
             ncout.createDimension("cell", n_cells)
             ncout.createDimension("nvertex", 6)
-    
+
             # Create coordinate variables
             ncout.createVariable("nav_lon", "f4", ("cell",))
             ncout.createVariable("nav_lat", "f4", ("cell",))
@@ -135,42 +143,50 @@ def write(varlist, resultpath, IDx):
             ncout.createVariable("bounds_lon", "f4", ("cell", "nvertex"))
             ncout.createVariable("bounds_lat", "f4", ("cell", "nvertex"))
             ncout.createVariable("Areas", "f4", ("cell",))
-    
+
             # Copy attributes for nav_lon/nav_lat
             for v in ["nav_lon", "nav_lat"]:
                 ncout.variables[v].setncatts(nc.variables[v].__dict__)
-    
+
             # Assign coordinates
             selected_lons = lon[ilons]
             selected_lats = lat[ilats]
-    
+
             ncout.variables["nav_lon"][:] = selected_lons
             ncout.variables["nav_lat"][:] = selected_lats
             ncout.variables["lon"][:] = selected_lons
             ncout.variables["lat"][:] = selected_lats
-    
+
             # Example bounding coordinates (hexagon)
-            ncout.variables["bounds_lon"][:, :] = np.array([
-                [lo-0.25, lo, lo+0.25, lo+0.25, lo, lo-0.25] for lo in selected_lons
-            ])
-            ncout.variables["bounds_lat"][:, :] = np.array([
-                [la+0.25, la+0.25, la+0.25, la-0.25, la-0.25, la-0.25] for la in selected_lats
-            ])
+            ncout.variables["bounds_lon"][:, :] = np.array(
+                [
+                    [lo - 0.25, lo, lo + 0.25, lo + 0.25, lo, lo - 0.25]
+                    for lo in selected_lons
+                ]
+            )
+            ncout.variables["bounds_lat"][:, :] = np.array(
+                [
+                    [la + 0.25, la + 0.25, la + 0.25, la - 0.25, la - 0.25, la - 0.25]
+                    for la in selected_lats
+                ]
+            )
             ncout.variables["Areas"][:] = np.array([2.5e9 for _ in range(n_cells)])
-    
+
             # Create time variables
             ncout.createVariable("time_counter", "f8", ("tstep",))
             ncout.createVariable("timeplussix", "f8", ("tstep",))
             ncout.variables["time_counter"].setncatts(nc.variables["time"].__dict__)
-            ncout.variables["timeplussix"].setncatts(nc.variables["timeplussix"].__dict__)
+            ncout.variables["timeplussix"].setncatts(
+                nc.variables["timeplussix"].__dict__
+            )
             ncout.variables["time_counter"][:] = nc.variables["time"][:]
             ncout.variables["timeplussix"][:] = nc.variables["timeplussix"][:]
-    
+
             # Copy remaining variables
             for var in nc.variables:
                 if var in ["nav_lon", "nav_lat", "time", "timeplussix", "fd"]:
                     continue
-    
+
                 dims = nc.variables[var].dimensions
                 dtype = nc.variables[var].dtype
                 if len(dims) == 3:
@@ -179,113 +195,123 @@ def write(varlist, resultpath, IDx):
                     newdims = ("cell",)
                 else:
                     newdims = dims
-    
-                fill_value = np.finfo(dtype).max if np.issubdtype(dtype, np.floating) else None
+
+                fill_value = (
+                    np.finfo(dtype).max if np.issubdtype(dtype, np.floating) else None
+                )
                 if fill_value is not None:
                     ncout.createVariable(var, dtype, newdims, fill_value=fill_value)
                 else:
                     ncout.createVariable(var, dtype, newdims)
-    
-                ncout.variables[var].setncatts({
-                    k: v for k, v in nc.variables[var].__dict__.items() if k not in ["_FillValue", "missing_value"]
-                })
-    
+
+                ncout.variables[var].setncatts(
+                    {
+                        k: v
+                        for k, v in nc.variables[var].__dict__.items()
+                        if k not in ["_FillValue", "missing_value"]
+                    }
+                )
+
                 # Extract data for selected pixels
                 if len(dims) == 3:
                     ncdata = nc.variables[var][:]
-                    ncout.variables[var][:] = np.array([ncdata[:, ilat, ilon] for ilat, ilon in zip(ilats, ilons)]).T
+                    ncout.variables[var][:] = np.array(
+                        [ncdata[:, ilat, ilon] for ilat, ilon in zip(ilats, ilons)]
+                    ).T
                 elif len(dims) == 2:
                     ncdata = nc.variables[var][:]
-                    ncout.variables[var][:] = np.array([ncdata[ilat, ilon] for ilat, ilon in zip(ilats, ilons)])
+                    ncout.variables[var][:] = np.array(
+                        [ncdata[ilat, ilon] for ilat, ilon in zip(ilats, ilons)]
+                    )
                 else:
                     ncout.variables[var][:] = nc.variables[var][:]
-    
-            nc.close()
-            ncout.close()    
 
-#    # build compressed forcing
-#    if mode == "compressed":
-#        for year in range(
-#            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
-#        ):
-#            print("Building compressed forcing for year %s" % year)
-#            nc = Dataset(
-#                varlist["climate"]["sourcepath"]
-#                + varlist["climate"]["filename"]
-#                + str(year)
-#                + ".nc"
-#            )
-#            # ncout = Dataset(resultpath + "forcing_compressed_" + str(year) + ".nc", "w")
-#            ncout = Dataset(str(resultpath / f"forcing_compressed_{year}.nc"), "w")
-#
-#            for dim in nc.dimensions:
-#                newdim = (
-#                    "x"
-#                    if dim in ["lon", "longitude"]
-#                    else "y"
-#                    if dim in ["lat", "latitude"]
-#                    else dim
-#                )
-#                newsize = (
-#                    len(xlands)
-#                    if dim == "land"
-#                    else (
-#                        None
-#                        if nc.dimensions[dim].isunlimited()
-#                        else len(nc.dimensions[dim])
-#                    )
-#                )
-#                ncout.createDimension(newdim, newsize)
-#            if "land" not in ncout.dimensions:
-#                ncout.createDimension("land", len(xlands))
-#                ncout.createVariable("land", "i4", ("land",))
-#                ncout.variables["land"].setncattr("compress", "y x")
-#                ncout.variables["land"][:] = xlands
-#            for var in nc.variables:
-#                print(var)
-#                if len(nc.variables[var].dimensions) == 3:
-#                    newdims = (nc.variables[var].dimensions[0], "land")
-#                elif (
-#                    "land" not in nc.dimensions
-#                    and len(nc.variables[var].dimensions) == 2
-#                ):
-#                    newdims = ("y", "x")
-#                else:
-#                    newdims = nc.variables[var].dimensions
-#                if var in ["land", "nav_lon", "nav_lat", "time", "timeplussix"]:
-#                    ncout.createVariable(var, nc.variables[var].dtype, newdims)
-#                else:
-#                    ncout.createVariable(
-#                        var,
-#                        nc.variables[var].dtype,
-#                        newdims,
-#                        fill_value=9.96921e36,
-#                        zlib=True,
-#                    )
-#                atts = dict()
-#                for key, value in nc.variables[var].__dict__.items():
-#                    if key not in ["_FillValue", "missing_value"]:
-#                        atts[key] = value
-#                ncout.variables[var].setncatts(atts)
-#                if var == "land":
-#                    ncout.variables[var][:] = xlands
-#                elif len(nc.variables[var].dimensions) == 3:
-#                    ncdata = nc.variables[var][:]
-#                    ncout.variables[var][:] = ncdata.reshape(
-#                        len(ncdata), len(lat) * len(lon)
-#                    )[:, xlands - 1]
-#                elif nc.variables[var].dimensions[-1] == "land":
-#                    ncdata = nc.variables[var][:]
-#                    ncout.variables[var][:] = ncdata[:, ilands]
-#                elif var.lower() in ["contfrac"]:
-#                    ncdata = nc.variables[var][:]
-#                    data = np.ma.masked_all((len(lat), len(lon)))
-#                    data[ilats, ilons] = ncdata[ilats, ilons]
-#                    ncout.variables[var][:] = data
-#                else:
-#                    ncout.variables[var][:] = nc.variables[var][:]
-#            ncout.close()
-#            nc.close()
+            nc.close()
+            ncout.close()
+
+    #    # build compressed forcing
+    #    if mode == "compressed":
+    #        for year in range(
+    #            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
+    #        ):
+    #            print("Building compressed forcing for year %s" % year)
+    #            nc = Dataset(
+    #                varlist["climate"]["sourcepath"]
+    #                + varlist["climate"]["filename"]
+    #                + str(year)
+    #                + ".nc"
+    #            )
+    #            # ncout = Dataset(resultpath + "forcing_compressed_" + str(year) + ".nc", "w")
+    #            ncout = Dataset(str(resultpath / f"forcing_compressed_{year}.nc"), "w")
+    #
+    #            for dim in nc.dimensions:
+    #                newdim = (
+    #                    "x"
+    #                    if dim in ["lon", "longitude"]
+    #                    else "y"
+    #                    if dim in ["lat", "latitude"]
+    #                    else dim
+    #                )
+    #                newsize = (
+    #                    len(xlands)
+    #                    if dim == "land"
+    #                    else (
+    #                        None
+    #                        if nc.dimensions[dim].isunlimited()
+    #                        else len(nc.dimensions[dim])
+    #                    )
+    #                )
+    #                ncout.createDimension(newdim, newsize)
+    #            if "land" not in ncout.dimensions:
+    #                ncout.createDimension("land", len(xlands))
+    #                ncout.createVariable("land", "i4", ("land",))
+    #                ncout.variables["land"].setncattr("compress", "y x")
+    #                ncout.variables["land"][:] = xlands
+    #            for var in nc.variables:
+    #                print(var)
+    #                if len(nc.variables[var].dimensions) == 3:
+    #                    newdims = (nc.variables[var].dimensions[0], "land")
+    #                elif (
+    #                    "land" not in nc.dimensions
+    #                    and len(nc.variables[var].dimensions) == 2
+    #                ):
+    #                    newdims = ("y", "x")
+    #                else:
+    #                    newdims = nc.variables[var].dimensions
+    #                if var in ["land", "nav_lon", "nav_lat", "time", "timeplussix"]:
+    #                    ncout.createVariable(var, nc.variables[var].dtype, newdims)
+    #                else:
+    #                    ncout.createVariable(
+    #                        var,
+    #                        nc.variables[var].dtype,
+    #                        newdims,
+    #                        fill_value=9.96921e36,
+    #                        zlib=True,
+    #                    )
+    #                atts = dict()
+    #                for key, value in nc.variables[var].__dict__.items():
+    #                    if key not in ["_FillValue", "missing_value"]:
+    #                        atts[key] = value
+    #                ncout.variables[var].setncatts(atts)
+    #                if var == "land":
+    #                    ncout.variables[var][:] = xlands
+    #                elif len(nc.variables[var].dimensions) == 3:
+    #                    ncdata = nc.variables[var][:]
+    #                    ncout.variables[var][:] = ncdata.reshape(
+    #                        len(ncdata), len(lat) * len(lon)
+    #                    )[:, xlands - 1]
+    #                elif nc.variables[var].dimensions[-1] == "land":
+    #                    ncdata = nc.variables[var][:]
+    #                    ncout.variables[var][:] = ncdata[:, ilands]
+    #                elif var.lower() in ["contfrac"]:
+    #                    ncdata = nc.variables[var][:]
+    #                    data = np.ma.masked_all((len(lat), len(lon)))
+    #                    data[ilats, ilons] = ncdata[ilats, ilons]
+    #                    ncout.variables[var][:] = data
+    #                else:
+    #                    ncout.variables[var][:] = nc.variables[var][:]
+    #            ncout.close()
+    #            nc.close()
 
     # build regular forcing
     if mode == "regular":
@@ -299,7 +325,7 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            #ncout = Dataset(resultpath + "forcing_regular_" + str(year) + ".nc", "w")
+            # ncout = Dataset(resultpath + "forcing_regular_" + str(year) + ".nc", "w")
             ncout = Dataset(str(resultpath / f"forcing_regular_{year}.nc"), "w")
 
             for dim in nc.dimensions:
@@ -383,8 +409,8 @@ def write(varlist, resultpath, IDx):
             nc.close()
 
     # build regular restart files (also used with compressed forcing)
-    #if mode == "compressed" or mode == "regular" or mode=="unstructured" :
-    if mode == "regular" :
+    # if mode == "compressed" or mode == "regular" or mode=="unstructured" :
+    if mode == "regular":
         for path in varlist["restart"]:
             print("Building regular restart file for", path)
             nc = Dataset(path)
@@ -419,15 +445,18 @@ def write(varlist, resultpath, IDx):
     if mode == "unstructured":
         for path in varlist["restart"]:
             print("Building unstructured restart file for", path)
-    
+
             nc = Dataset(path)
-            outfile = str(resultpath / f"{os.path.basename(path).replace('.nc', '_unstructured.nc')}")
+            outfile = str(
+                resultpath
+                / f"{os.path.basename(path).replace('.nc', '_unstructured.nc')}"
+            )
             ncout = Dataset(outfile, "w")
-    
+
             # ------------------------------
             # Create dimensions
             # ------------------------------
-            #for dim in nc.dimensions:
+            # for dim in nc.dimensions:
             #    if dim == "y":
             #        ncout.createDimension("y", len(ilats))  # number of selected pixels
             #    elif dim in ["x", "x_a"] :
@@ -442,7 +471,7 @@ def write(varlist, resultpath, IDx):
             #        )
             # Track which new dimensions we already created
             created_dims = set()
-            
+
             for dim in nc.dimensions:
                 if dim == "y":
                     if "y" not in created_dims:
@@ -456,44 +485,53 @@ def write(varlist, resultpath, IDx):
                     if dim not in created_dims:
                         ncout.createDimension(
                             dim,
-                            None if nc.dimensions[dim].isunlimited() else len(nc.dimensions[dim])
+                            None
+                            if nc.dimensions[dim].isunlimited()
+                            else len(nc.dimensions[dim]),
                         )
                         created_dims.add(dim)
-    
+
             # ------------------------------
             # Create variables with correct fill values
             # ------------------------------
             for var in nc.variables:
                 dims = nc.variables[var].dimensions
-                new_dims = tuple('y' if d == 'y' else 'x' if d in ['x', 'x_a'] else d for d in dims)
+                new_dims = tuple(
+                    "y" if d == "y" else "x" if d in ["x", "x_a"] else d for d in dims
+                )
 
                 var_dtype = nc.variables[var].dtype
-    
+
                 # Determine fill value
                 if np.issubdtype(var_dtype, np.floating):
-                    fill_value = 1.e20
+                    fill_value = 1.0e20
                 elif np.issubdtype(var_dtype, np.integer):
                     fill_value = np.iinfo(var_dtype).max
                 else:
                     fill_value = None
-    
+
                 # Create variable
                 if fill_value is not None:
-                    ncout.createVariable(var, var_dtype, new_dims, fill_value=fill_value)
+                    ncout.createVariable(
+                        var, var_dtype, new_dims, fill_value=fill_value
+                    )
                 else:
                     ncout.createVariable(var, var_dtype, new_dims)
-    
+
                 # Copy attributes except _FillValue and missing_value
-                ncout.variables[var].setncatts({
-                    k: v for k, v in nc.variables[var].__dict__.items()
-                    if k not in ["_FillValue", "missing_value"]
-                })
-    
+                ncout.variables[var].setncatts(
+                    {
+                        k: v
+                        for k, v in nc.variables[var].__dict__.items()
+                        if k not in ["_FillValue", "missing_value"]
+                    }
+                )
+
                 # ------------------------------
                 # Copy data with proper pixel selection
                 # ------------------------------
                 data = nc.variables[var][:]
-    
+
                 if "y" in new_dims and "x" in new_dims:
                     # multi-dimensional spatial variables
                     y_pos = new_dims.index("y")
@@ -502,46 +540,47 @@ def write(varlist, resultpath, IDx):
                     new_shape[y_pos] = len(ilats)
                     new_shape[x_pos] = 1
                     new_data = np.ma.masked_all(new_shape, dtype=data.dtype)
-    
+
                     for i, (ilat, ilon) in enumerate(zip(ilats, ilons)):
                         src_idx = [slice(None)] * data.ndim
                         src_idx[y_pos] = ilat
                         src_idx[x_pos] = ilon
-    
+
                         dst_idx = [slice(None)] * len(new_shape)
                         dst_idx[y_pos] = i
                         dst_idx[x_pos] = 0
-    
+
                         new_data[tuple(dst_idx)] = data[tuple(src_idx)]
-    
+
                     ncout.variables[var][:] = new_data
-    
+
                 elif "y" in new_dims and "x" not in new_dims:
                     # 1D spatial variables (y only)
                     y_pos = new_dims.index("y")
                     new_shape = list(data.shape)
                     new_shape[y_pos] = len(ilats)
                     new_data = np.ma.masked_all(new_shape, dtype=data.dtype)
-    
+
                     for i, ilat in enumerate(ilats):
                         src_idx = [slice(None)] * data.ndim
                         src_idx[y_pos] = ilat
-    
+
                         dst_idx = [slice(None)] * len(new_shape)
                         dst_idx[y_pos] = i
-    
+
                         new_data[tuple(dst_idx)] = data[tuple(src_idx)]
-    
+
                     ncout.variables[var][:] = new_data
-    
+
                 else:
                     # Non-spatial variables, copy directly
                     ncout.variables[var][:] = data
-    
+
             nc.close()
             ncout.close()
             print(f"Saved unstructured restart file: {outfile}")
-   
+
+
 #    # build aligned forcing
 #    if mode == "aligned":
 #        nlat = int(np.ceil((len(IDx) / 2) ** 0.5))

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -4,7 +4,7 @@ def write(varlist, resultpath, IDx):
     # select mode to build forcing and restart files
     # possible modes: compressed, regular, aligned
     #mode = "unstructured"
-    mode = varlist["resp"]["mode"]
+    mode = varlist["resp"]["format"]
 
     # define indices of selected pixels using the first forcing year
     nc = Dataset(
@@ -424,66 +424,82 @@ def write(varlist, resultpath, IDx):
             outfile = str(resultpath / f"{os.path.basename(path).replace('.nc', '_unstructured.nc')}")
             ncout = Dataset(outfile, "w")
     
-            # ------------------------------
             # Create dimensions
-            # ------------------------------
             for dim in nc.dimensions:
                 if dim == "y":
-                    ncout.createDimension("y", len(ilats))  # number of unique pixels
+                    ncout.createDimension("cell", len(ilats))  # single cell dimension
+                    # NOTE: do NOT create "x" dimension
                 elif dim == "x":
-                    ncout.createDimension("x", 1)
+                    continue  # Skip x dimension entirely for unstructured
                 else:
                     ncout.createDimension(dim, len(nc.dimensions[dim]) if not nc.dimensions[dim].isunlimited() else None)
     
-            # ------------------------------
-            # Create variables
-            # ------------------------------
+            # Create and assign variables
             for var in nc.variables:
                 dims = list(nc.variables[var].dimensions)
                 dtype = nc.variables[var].dtype
                 fill_value = nc.variables[var]._FillValue if "_FillValue" in nc.variables[var].ncattrs() else None
     
-                # Replace 'y' and 'x' dimensions
-                new_dims = ["y" if d == "y" else "x" if d == "x" else d for d in dims]
+                # Replace 'y' with 'cell', and DROP 'x' entirely
+                new_dims = []
+                for d in dims:
+                    if d == "y":
+                        new_dims.append("cell")
+                    elif d == "x":
+                        continue  # Skip x - do NOT include it in new_dims
+                    else:
+                        new_dims.append(d)
     
                 if fill_value is not None:
-                    ncout.createVariable(var, dtype, new_dims, fill_value=fill_value)
+                    ncout.createVariable(var, dtype, tuple(new_dims), fill_value=fill_value)
                 else:
-                    ncout.createVariable(var, dtype, new_dims)
+                    ncout.createVariable(var, dtype, tuple(new_dims))
     
                 # Copy variable attributes
                 ncout.variables[var].setncatts({
                     k: v for k, v in nc.variables[var].__dict__.items() if k not in ["_FillValue", "missing_value"]
                 })
     
-                # ------------------------------
-                # Assign data
-                # ------------------------------
+                # Assign data - SQUEEZE out the x dimension (which has size 1)
                 data = nc.variables[var][:]
                 if "y" in dims and "x" in dims:
-                    # Find positions
+                    # Find positions of y and x
                     y_pos = dims.index("y")
                     x_pos = dims.index("x")
     
-                    # Prepare new array
+                    # Prepare new array WITHOUT the x dimension
                     new_shape = list(data.shape)
                     new_shape[y_pos] = len(ilats)
-                    new_shape[x_pos] = 1
+                    # Remove x_pos dimension size
+                    new_shape.pop(x_pos)
                     new_data = np.ma.masked_all(new_shape, dtype=dtype)
     
-                    # Copy selected pixels
+                    # Copy selected pixels (iterate over the cell dimension)
                     for i, (ilat, ilon) in enumerate(zip(ilats, ilons)):
+                        # Source indices: ilat at y_pos, ilon at x_pos
                         idx_src = [slice(None)] * len(data.shape)
                         idx_src[y_pos] = ilat
                         idx_src[x_pos] = ilon
-    
-                        idx_dst = [slice(None)] * len(data.shape)
+                        
+                        # Destination indices: i at y_pos (now renamed to cell), NO x dimension
+                        idx_dst = [slice(None)] * len(new_shape)
                         idx_dst[y_pos] = i
-                        idx_dst[x_pos] = 0
     
                         new_data[tuple(idx_dst)] = data[tuple(idx_src)]
     
+                    # Squeeze to remove any singleton dimensions (optional, but recommended)
+                    new_data = np.squeeze(new_data)
                     ncout.variables[var][:] = new_data
+                elif "y" in dims:
+                    # Only y dimension (no x) - just copy by selecting ilats
+                    data_selected = np.ma.masked_all((len(ilats),) + data.shape[1:], dtype=dtype)
+                    for i, ilat in enumerate(ilats):
+                        idx_src = [slice(None)] * len(data.shape)
+                        idx_src[dims.index("y")] = ilat
+                        idx_dst = [slice(None)] * len(data_selected.shape)
+                        idx_dst[0] = i
+                        data_selected[tuple(idx_dst)] = data[tuple(idx_src)]
+                    ncout.variables[var][:] = data_selected
                 else:
                     # Non-spatial or already compatible
                     ncout.variables[var][:] = data

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -241,7 +241,7 @@ def write(varlist, resultpath, IDx):
         for path in varlist["restart"]:
             print("Building regular restart file for", path)
             nc = Dataset(path)
-            ncout = Dataset(resultpath + os.path.split(path)[-1], "w")
+            ncout = Dataset(resultpath / os.path.split(path)[-1], "w")
             for dim in nc.dimensions:
                 ncout.createDimension(
                     dim,
@@ -291,7 +291,8 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            ncout = Dataset(resultpath + "forcing_aligned_" + str(year) + ".nc", "w")
+            ncout = Dataset(resultpath / f"forcing_aligned_{year}.nc", "w")
+
             for dim in nc.dimensions:
                 if dim == "land":
                     continue

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -414,7 +414,7 @@ def write(varlist, resultpath, IDx):
             ncout.close()
 
     # ------------------------------
-    # Unstructured restart files
+    # Build pseudo-unstructured restart files (y, x=1 layout)
     # ------------------------------
     if mode == "unstructured":
         for path in varlist["restart"]:
@@ -424,88 +424,123 @@ def write(varlist, resultpath, IDx):
             outfile = str(resultpath / f"{os.path.basename(path).replace('.nc', '_unstructured.nc')}")
             ncout = Dataset(outfile, "w")
     
+            # ------------------------------
             # Create dimensions
+            # ------------------------------
+            #for dim in nc.dimensions:
+            #    if dim == "y":
+            #        ncout.createDimension("y", len(ilats))  # number of selected pixels
+            #    elif dim in ["x", "x_a"] :
+            #         if "x" not in created_dims:
+            #             ncout.createDimension("x", 1)  # singleton x dimension
+            #             created_dims.add("x")
+            #    else:
+            #        ncout.createDimension(
+            #            dim,
+            #            None if nc.dimensions[dim].isunlimited()
+            #            else len(nc.dimensions[dim])
+            #        )
+            # Track which new dimensions we already created
+            created_dims = set()
+            
             for dim in nc.dimensions:
                 if dim == "y":
-                    ncout.createDimension("cell", len(ilats))  # single cell dimension
-                    # NOTE: do NOT create "x" dimension
-                elif dim == "x":
-                    continue  # Skip x dimension entirely for unstructured
+                    if "y" not in created_dims:
+                        ncout.createDimension("y", len(ilats))
+                        created_dims.add("y")
+                elif dim in ["x", "x_a"]:
+                    if "x" not in created_dims:
+                        ncout.createDimension("x", 1)  # singleton x dimension
+                        created_dims.add("x")
                 else:
-                    ncout.createDimension(dim, len(nc.dimensions[dim]) if not nc.dimensions[dim].isunlimited() else None)
+                    if dim not in created_dims:
+                        ncout.createDimension(
+                            dim,
+                            None if nc.dimensions[dim].isunlimited() else len(nc.dimensions[dim])
+                        )
+                        created_dims.add(dim)
     
-            # Create and assign variables
+            # ------------------------------
+            # Create variables with correct fill values
+            # ------------------------------
             for var in nc.variables:
-                dims = list(nc.variables[var].dimensions)
-                dtype = nc.variables[var].dtype
-                fill_value = nc.variables[var]._FillValue if "_FillValue" in nc.variables[var].ncattrs() else None
+                dims = nc.variables[var].dimensions
+                new_dims = tuple('y' if d == 'y' else 'x' if d in ['x', 'x_a'] else d for d in dims)
+
+                var_dtype = nc.variables[var].dtype
     
-                # Replace 'y' with 'cell', and DROP 'x' entirely
-                new_dims = []
-                for d in dims:
-                    if d == "y":
-                        new_dims.append("cell")
-                    elif d == "x":
-                        continue  # Skip x - do NOT include it in new_dims
-                    else:
-                        new_dims.append(d)
-    
-                if fill_value is not None:
-                    ncout.createVariable(var, dtype, tuple(new_dims), fill_value=fill_value)
+                # Determine fill value
+                if np.issubdtype(var_dtype, np.floating):
+                    fill_value = 1.e20
+                elif np.issubdtype(var_dtype, np.integer):
+                    fill_value = np.iinfo(var_dtype).max
                 else:
-                    ncout.createVariable(var, dtype, tuple(new_dims))
+                    fill_value = None
     
-                # Copy variable attributes
+                # Create variable
+                if fill_value is not None:
+                    ncout.createVariable(var, var_dtype, new_dims, fill_value=fill_value)
+                else:
+                    ncout.createVariable(var, var_dtype, new_dims)
+    
+                # Copy attributes except _FillValue and missing_value
                 ncout.variables[var].setncatts({
-                    k: v for k, v in nc.variables[var].__dict__.items() if k not in ["_FillValue", "missing_value"]
+                    k: v for k, v in nc.variables[var].__dict__.items()
+                    if k not in ["_FillValue", "missing_value"]
                 })
     
-                # Assign data - SQUEEZE out the x dimension (which has size 1)
+                # ------------------------------
+                # Copy data with proper pixel selection
+                # ------------------------------
                 data = nc.variables[var][:]
-                if "y" in dims and "x" in dims:
-                    # Find positions of y and x
-                    y_pos = dims.index("y")
-                    x_pos = dims.index("x")
     
-                    # Prepare new array WITHOUT the x dimension
+                if "y" in new_dims and "x" in new_dims:
+                    # multi-dimensional spatial variables
+                    y_pos = new_dims.index("y")
+                    x_pos = new_dims.index("x")
                     new_shape = list(data.shape)
                     new_shape[y_pos] = len(ilats)
-                    # Remove x_pos dimension size
-                    new_shape.pop(x_pos)
-                    new_data = np.ma.masked_all(new_shape, dtype=dtype)
+                    new_shape[x_pos] = 1
+                    new_data = np.ma.masked_all(new_shape, dtype=data.dtype)
     
-                    # Copy selected pixels (iterate over the cell dimension)
                     for i, (ilat, ilon) in enumerate(zip(ilats, ilons)):
-                        # Source indices: ilat at y_pos, ilon at x_pos
-                        idx_src = [slice(None)] * len(data.shape)
-                        idx_src[y_pos] = ilat
-                        idx_src[x_pos] = ilon
-                        
-                        # Destination indices: i at y_pos (now renamed to cell), NO x dimension
-                        idx_dst = [slice(None)] * len(new_shape)
-                        idx_dst[y_pos] = i
+                        src_idx = [slice(None)] * data.ndim
+                        src_idx[y_pos] = ilat
+                        src_idx[x_pos] = ilon
     
-                        new_data[tuple(idx_dst)] = data[tuple(idx_src)]
+                        dst_idx = [slice(None)] * len(new_shape)
+                        dst_idx[y_pos] = i
+                        dst_idx[x_pos] = 0
     
-                    # Squeeze to remove any singleton dimensions (optional, but recommended)
-                    new_data = np.squeeze(new_data)
+                        new_data[tuple(dst_idx)] = data[tuple(src_idx)]
+    
                     ncout.variables[var][:] = new_data
-                elif "y" in dims:
-                    # Only y dimension (no x) - just copy by selecting ilats
-                    data_selected = np.ma.masked_all((len(ilats),) + data.shape[1:], dtype=dtype)
+    
+                elif "y" in new_dims and "x" not in new_dims:
+                    # 1D spatial variables (y only)
+                    y_pos = new_dims.index("y")
+                    new_shape = list(data.shape)
+                    new_shape[y_pos] = len(ilats)
+                    new_data = np.ma.masked_all(new_shape, dtype=data.dtype)
+    
                     for i, ilat in enumerate(ilats):
-                        idx_src = [slice(None)] * len(data.shape)
-                        idx_src[dims.index("y")] = ilat
-                        idx_dst = [slice(None)] * len(data_selected.shape)
-                        idx_dst[0] = i
-                        data_selected[tuple(idx_dst)] = data[tuple(idx_src)]
-                    ncout.variables[var][:] = data_selected
+                        src_idx = [slice(None)] * data.ndim
+                        src_idx[y_pos] = ilat
+    
+                        dst_idx = [slice(None)] * len(new_shape)
+                        dst_idx[y_pos] = i
+    
+                        new_data[tuple(dst_idx)] = data[tuple(src_idx)]
+    
+                    ncout.variables[var][:] = new_data
+    
                 else:
-                    # Non-spatial or already compatible
+                    # Non-spatial variables, copy directly
                     ncout.variables[var][:] = data
     
             nc.close()
             ncout.close()
+            print(f"Saved unstructured restart file: {outfile}")
    
 #    # build aligned forcing
 #    if mode == "aligned":

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -325,7 +325,6 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            # ncout = Dataset(resultpath + "forcing_regular_" + str(year) + ".nc", "w")
             ncout = Dataset(str(resultpath / f"forcing_regular_{year}.nc"), "w")
 
             for dim in nc.dimensions:
@@ -456,19 +455,7 @@ def write(varlist, resultpath, IDx):
             # ------------------------------
             # Create dimensions
             # ------------------------------
-            # for dim in nc.dimensions:
-            #    if dim == "y":
-            #        ncout.createDimension("y", len(ilats))  # number of selected pixels
-            #    elif dim in ["x", "x_a"] :
-            #         if "x" not in created_dims:
-            #             ncout.createDimension("x", 1)  # singleton x dimension
-            #             created_dims.add("x")
-            #    else:
-            #        ncout.createDimension(
-            #            dim,
-            #            None if nc.dimensions[dim].isunlimited()
-            #            else len(nc.dimensions[dim])
-            #        )
+
             # Track which new dimensions we already created
             created_dims = set()
 

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -73,7 +73,7 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            ncout = Dataset(resultpath + "forcing_compressed_" + str(year) + ".nc", "w")
+            ncout = Dataset(str(resultpath / f"forcing_compressed_{year}.nc"), "w")
             for dim in nc.dimensions:
                 newdim = (
                     "x"
@@ -155,7 +155,7 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            ncout = Dataset(resultpath + "forcing_regular_" + str(year) + ".nc", "w")
+            ncout = Dataset(str(resultpath / f"forcing_regular_{year}.nc"), "w")
             for dim in nc.dimensions:
                 if dim == "land":
                     continue

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -1,10 +1,9 @@
 from Tools import *
 
-
 def write(varlist, resultpath, IDx):
     # select mode to build forcing and restart files
     # possible modes: compressed, regular, aligned
-    mode = "compressed"
+    mode = "unstructured"
 
     # define indices of selected pixels using the first forcing year
     nc = Dataset(
@@ -44,6 +43,7 @@ def write(varlist, resultpath, IDx):
     for xlat, xlon in IDx:
         ilat = np.where(xlat == lat)[0][0]
         ilon = np.where(xlon == lon)[0][0]
+
         xland = ilat * len(lon) + ilon + 1
         if xland in xlands:
             continue
@@ -61,87 +61,230 @@ def write(varlist, resultpath, IDx):
     xlands = np.array(xlands)
     nc.close()
 
-    # build compressed forcing
-    if mode == "compressed":
-        for year in range(
-            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
-        ):
-            print("Building compressed forcing for year %s" % year)
+    # ------------------------------
+    # Unstructured mode
+    # ------------------------------
+    if mode == "unstructured":
+        # Open first year's dataset to read grid
+        nc_first = Dataset(
+            varlist["climate"]["sourcepath"]
+            + varlist["climate"]["filename"]
+            + str(varlist["climate"]["year_start"])
+            + ".nc"
+        )
+    
+        lat = nc_first.variables.get("lat", nc_first.variables.get("latitude", nc_first.variables.get("nav_lat")))[:]
+        lon = nc_first.variables.get("lon", nc_first.variables.get("longitude", nc_first.variables.get("nav_lon")))[:]
+        if len(lat.shape) > 1:
+            lat = lat[:, 0]
+        if len(lon.shape) > 1:
+            lon = lon[0, :]
+        land = nc_first.variables["land"][:] if "land" in nc_first.dimensions else None
+    
+        # Build unique pixel indices
+        unique_pixels = set()
+        ilats, ilons, ilands, xlands = [], [], [], []
+        for xlat, xlon in IDx:
+            ilat = np.argmin(np.abs(lat - xlat))
+            ilon = np.argmin(np.abs(lon - xlon))
+    
+            if (ilat, ilon) in unique_pixels:
+                continue
+            unique_pixels.add((ilat, ilon))
+    
+            xland = ilat * len(lon) + ilon + 1
+            iland = np.where(land == xland)[0][0] if land is not None else None
+    
+            ilats.append(ilat)
+            ilons.append(ilon)
+            ilands.append(iland)
+            xlands.append(xland)
+    
+        ilats = np.array(ilats)
+        ilons = np.array(ilons)
+        ilands = np.array(ilands)
+        xlands = np.array(xlands)
+        nc_first.close()
+    
+        n_cells = len(ilats)  # number of unique pixels
+    
+        # Process each year
+        for year in range(varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1):
+            print(f"Building unstructured forcing for year {year}")
+    
             nc = Dataset(
                 varlist["climate"]["sourcepath"]
                 + varlist["climate"]["filename"]
                 + str(year)
                 + ".nc"
             )
-            ncout = Dataset(str(resultpath / f"forcing_compressed_{year}.nc"), "w")
-            for dim in nc.dimensions:
-                newdim = (
-                    "x"
-                    if dim in ["lon", "longitude"]
-                    else "y"
-                    if dim in ["lat", "latitude"]
-                    else dim
-                )
-                newsize = (
-                    len(xlands)
-                    if dim == "land"
-                    else (
-                        None
-                        if nc.dimensions[dim].isunlimited()
-                        else len(nc.dimensions[dim])
-                    )
-                )
-                ncout.createDimension(newdim, newsize)
-            if "land" not in ncout.dimensions:
-                ncout.createDimension("land", len(xlands))
-                ncout.createVariable("land", "i4", ("land",))
-                ncout.variables["land"].setncattr("compress", "y x")
-                ncout.variables["land"][:] = xlands
+    
+            ncout = Dataset(str(resultpath / f"forcing_unstructured_{year}.nc"), "w")
+    
+            # Define dimensions
+            ncout.createDimension("tstep", None)
+            ncout.createDimension("cell", n_cells)
+            ncout.createDimension("nvertex", 6)
+    
+            # Create coordinate variables
+            ncout.createVariable("nav_lon", "f4", ("cell",))
+            ncout.createVariable("nav_lat", "f4", ("cell",))
+            ncout.createVariable("lon", "f4", ("cell",))
+            ncout.createVariable("lat", "f4", ("cell",))
+            ncout.createVariable("bounds_lon", "f4", ("cell", "nvertex"))
+            ncout.createVariable("bounds_lat", "f4", ("cell", "nvertex"))
+            ncout.createVariable("Areas", "f4", ("cell",))
+    
+            # Copy attributes for nav_lon/nav_lat
+            for v in ["nav_lon", "nav_lat"]:
+                ncout.variables[v].setncatts(nc.variables[v].__dict__)
+    
+            # Assign coordinates
+            selected_lons = lon[ilons]
+            selected_lats = lat[ilats]
+    
+            ncout.variables["nav_lon"][:] = selected_lons
+            ncout.variables["nav_lat"][:] = selected_lats
+            ncout.variables["lon"][:] = selected_lons
+            ncout.variables["lat"][:] = selected_lats
+    
+            # Example bounding coordinates (hexagon)
+            ncout.variables["bounds_lon"][:, :] = np.array([
+                [lo-0.25, lo, lo+0.25, lo+0.25, lo, lo-0.25] for lo in selected_lons
+            ])
+            ncout.variables["bounds_lat"][:, :] = np.array([
+                [la+0.25, la+0.25, la+0.25, la-0.25, la-0.25, la-0.25] for la in selected_lats
+            ])
+            ncout.variables["Areas"][:] = np.array([2.5e9 for _ in range(n_cells)])
+    
+            # Create time variables
+            ncout.createVariable("time_counter", "f8", ("tstep",))
+            ncout.createVariable("timeplussix", "f8", ("tstep",))
+            ncout.variables["time_counter"].setncatts(nc.variables["time"].__dict__)
+            ncout.variables["timeplussix"].setncatts(nc.variables["timeplussix"].__dict__)
+            ncout.variables["time_counter"][:] = nc.variables["time"][:]
+            ncout.variables["timeplussix"][:] = nc.variables["timeplussix"][:]
+    
+            # Copy remaining variables
             for var in nc.variables:
-                print(var)
-                if len(nc.variables[var].dimensions) == 3:
-                    newdims = (nc.variables[var].dimensions[0], "land")
-                elif (
-                    "land" not in nc.dimensions
-                    and len(nc.variables[var].dimensions) == 2
-                ):
-                    newdims = ("y", "x")
+                if var in ["nav_lon", "nav_lat", "time", "timeplussix", "fd"]:
+                    continue
+    
+                dims = nc.variables[var].dimensions
+                dtype = nc.variables[var].dtype
+                if len(dims) == 3:
+                    newdims = ("tstep", "cell")
+                elif len(dims) == 2:
+                    newdims = ("cell",)
                 else:
-                    newdims = nc.variables[var].dimensions
-                if var in ["land", "nav_lon", "nav_lat", "time", "timeplussix"]:
-                    ncout.createVariable(var, nc.variables[var].dtype, newdims)
+                    newdims = dims
+    
+                fill_value = np.finfo(dtype).max if np.issubdtype(dtype, np.floating) else None
+                if fill_value is not None:
+                    ncout.createVariable(var, dtype, newdims, fill_value=fill_value)
                 else:
-                    ncout.createVariable(
-                        var,
-                        nc.variables[var].dtype,
-                        newdims,
-                        fill_value=9.96921e36,
-                        zlib=True,
-                    )
-                atts = dict()
-                for key, value in nc.variables[var].__dict__.items():
-                    if key not in ["_FillValue", "missing_value"]:
-                        atts[key] = value
-                ncout.variables[var].setncatts(atts)
-                if var == "land":
-                    ncout.variables[var][:] = xlands
-                elif len(nc.variables[var].dimensions) == 3:
+                    ncout.createVariable(var, dtype, newdims)
+    
+                ncout.variables[var].setncatts({
+                    k: v for k, v in nc.variables[var].__dict__.items() if k not in ["_FillValue", "missing_value"]
+                })
+    
+                # Extract data for selected pixels
+                if len(dims) == 3:
                     ncdata = nc.variables[var][:]
-                    ncout.variables[var][:] = ncdata.reshape(
-                        len(ncdata), len(lat) * len(lon)
-                    )[:, xlands - 1]
-                elif nc.variables[var].dimensions[-1] == "land":
+                    ncout.variables[var][:] = np.array([ncdata[:, ilat, ilon] for ilat, ilon in zip(ilats, ilons)]).T
+                elif len(dims) == 2:
                     ncdata = nc.variables[var][:]
-                    ncout.variables[var][:] = ncdata[:, ilands]
-                elif var.lower() in ["contfrac"]:
-                    ncdata = nc.variables[var][:]
-                    data = np.ma.masked_all((len(lat), len(lon)))
-                    data[ilats, ilons] = ncdata[ilats, ilons]
-                    ncout.variables[var][:] = data
+                    ncout.variables[var][:] = np.array([ncdata[ilat, ilon] for ilat, ilon in zip(ilats, ilons)])
                 else:
                     ncout.variables[var][:] = nc.variables[var][:]
-            ncout.close()
+    
             nc.close()
+            ncout.close()    
+
+#    # build compressed forcing
+#    if mode == "compressed":
+#        for year in range(
+#            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
+#        ):
+#            print("Building compressed forcing for year %s" % year)
+#            nc = Dataset(
+#                varlist["climate"]["sourcepath"]
+#                + varlist["climate"]["filename"]
+#                + str(year)
+#                + ".nc"
+#            )
+#            # ncout = Dataset(resultpath + "forcing_compressed_" + str(year) + ".nc", "w")
+#            ncout = Dataset(str(resultpath / f"forcing_compressed_{year}.nc"), "w")
+#
+#            for dim in nc.dimensions:
+#                newdim = (
+#                    "x"
+#                    if dim in ["lon", "longitude"]
+#                    else "y"
+#                    if dim in ["lat", "latitude"]
+#                    else dim
+#                )
+#                newsize = (
+#                    len(xlands)
+#                    if dim == "land"
+#                    else (
+#                        None
+#                        if nc.dimensions[dim].isunlimited()
+#                        else len(nc.dimensions[dim])
+#                    )
+#                )
+#                ncout.createDimension(newdim, newsize)
+#            if "land" not in ncout.dimensions:
+#                ncout.createDimension("land", len(xlands))
+#                ncout.createVariable("land", "i4", ("land",))
+#                ncout.variables["land"].setncattr("compress", "y x")
+#                ncout.variables["land"][:] = xlands
+#            for var in nc.variables:
+#                print(var)
+#                if len(nc.variables[var].dimensions) == 3:
+#                    newdims = (nc.variables[var].dimensions[0], "land")
+#                elif (
+#                    "land" not in nc.dimensions
+#                    and len(nc.variables[var].dimensions) == 2
+#                ):
+#                    newdims = ("y", "x")
+#                else:
+#                    newdims = nc.variables[var].dimensions
+#                if var in ["land", "nav_lon", "nav_lat", "time", "timeplussix"]:
+#                    ncout.createVariable(var, nc.variables[var].dtype, newdims)
+#                else:
+#                    ncout.createVariable(
+#                        var,
+#                        nc.variables[var].dtype,
+#                        newdims,
+#                        fill_value=9.96921e36,
+#                        zlib=True,
+#                    )
+#                atts = dict()
+#                for key, value in nc.variables[var].__dict__.items():
+#                    if key not in ["_FillValue", "missing_value"]:
+#                        atts[key] = value
+#                ncout.variables[var].setncatts(atts)
+#                if var == "land":
+#                    ncout.variables[var][:] = xlands
+#                elif len(nc.variables[var].dimensions) == 3:
+#                    ncdata = nc.variables[var][:]
+#                    ncout.variables[var][:] = ncdata.reshape(
+#                        len(ncdata), len(lat) * len(lon)
+#                    )[:, xlands - 1]
+#                elif nc.variables[var].dimensions[-1] == "land":
+#                    ncdata = nc.variables[var][:]
+#                    ncout.variables[var][:] = ncdata[:, ilands]
+#                elif var.lower() in ["contfrac"]:
+#                    ncdata = nc.variables[var][:]
+#                    data = np.ma.masked_all((len(lat), len(lon)))
+#                    data[ilats, ilons] = ncdata[ilats, ilons]
+#                    ncout.variables[var][:] = data
+#                else:
+#                    ncout.variables[var][:] = nc.variables[var][:]
+#            ncout.close()
+#            nc.close()
 
     # build regular forcing
     if mode == "regular":
@@ -155,7 +298,9 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
+            #ncout = Dataset(resultpath + "forcing_regular_" + str(year) + ".nc", "w")
             ncout = Dataset(str(resultpath / f"forcing_regular_{year}.nc"), "w")
+
             for dim in nc.dimensions:
                 if dim == "land":
                     continue
@@ -237,7 +382,8 @@ def write(varlist, resultpath, IDx):
             nc.close()
 
     # build regular restart files (also used with compressed forcing)
-    if mode == "compressed" or mode == "regular":
+    #if mode == "compressed" or mode == "regular" or mode=="unstructured" :
+    if mode == "regular" :
         for path in varlist["restart"]:
             print("Building regular restart file for", path)
             nc = Dataset(path)
@@ -266,173 +412,251 @@ def write(varlist, resultpath, IDx):
             nc.close()
             ncout.close()
 
-    # build aligned forcing
-    if mode == "aligned":
-        nlat = int(np.ceil((len(IDx) / 2) ** 0.5))
-        nlon = nlat * 2
-        step = 180.0 / nlat
-        plat = np.arange(90 - step / 2.0, -90, -step)
-        plon = np.arange(-180 + step / 2.0, 180, step)
-        pnavlon, pnavlat = np.meshgrid(plon, plat)
-        alats = list()
-        alons = list()
-        for idx in range(len(xlands)):
-            alats.append(idx // nlon)
-            alons.append(idx % nlon)
-        alats = np.array(alats)
-        alons = np.array(alons)
-        for year in range(
-            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
-        ):
-            print("Building aligned forcing for year %s" % year)
-            nc = Dataset(
-                varlist["climate"]["sourcepath"]
-                + varlist["climate"]["filename"]
-                + str(year)
-                + ".nc"
-            )
-            ncout = Dataset(resultpath / f"forcing_aligned_{year}.nc", "w")
-
-            for dim in nc.dimensions:
-                if dim == "land":
-                    continue
-                newdim = (
-                    "lon"
-                    if dim in ["lon", "longitude", "x"]
-                    else "lat"
-                    if dim in ["lat", "latitude", "y"]
-                    else dim
-                )
-                newsize = (
-                    len(plat)
-                    if newdim == "lat"
-                    else (
-                        len(plon)
-                        if newdim == "lon"
-                        else (
-                            None
-                            if nc.dimensions[dim].isunlimited()
-                            else len(nc.dimensions[dim])
-                        )
-                    )
-                )
-                ncout.createDimension(newdim, newsize)
-            for var in nc.variables:
-                print(var)
-                if var == "land":
-                    continue
-                elif (
-                    len(nc.variables[var].dimensions) == 3
-                    or "land" in nc.variables[var].dimensions
-                ):
-                    newdims = (nc.variables[var].dimensions[0], "lat", "lon")
-                elif len(nc.variables[var].dimensions) == 2:
-                    newdims = ("lat", "lon")
-                elif nc.variables[var].dimensions[0] in ["lon", "longitude", "x"]:
-                    newdims = ("lon",)
-                elif nc.variables[var].dimensions[0] in ["lat", "latitude", "y"]:
-                    newdims = ("lat",)
-                else:
-                    newdims = nc.variables[var].dimensions
-                if len(newdims) > 2:
-                    ncout.createVariable(
-                        var,
-                        nc.variables[var].dtype,
-                        newdims,
-                        fill_value=9.96921e36,
-                        zlib=True,
-                    )
-                else:
-                    ncout.createVariable(
-                        var, nc.variables[var].dtype, newdims, fill_value=9.96921e36
-                    )
-                atts = dict()
-                for key, value in nc.variables[var].__dict__.items():
-                    if key not in ["_FillValue", "missing_value"]:
-                        atts[key] = value
-                ncout.variables[var].setncatts(atts)
-                if len(nc.variables[var].dimensions) == 3:
-                    ncdata = nc.variables[var][:]
-                    data = np.ma.masked_all((len(ncdata), nlat, nlon))
-                    data[:, alats, alons] = ncdata[:, ilats, ilons]
-                    ncout.variables[var][:] = data
-                    for idx in range(len(xlands)):
-                        ncout.variables[var][:, idx // nlon, idx % nlon] = nc.variables[
-                            var
-                        ][:, ilats[idx], ilons[idx]]
-                elif nc.variables[var].dimensions[-1] == "land":
-                    ncdata = nc.variables[var][:]
-                    data = np.ma.masked_all((len(ncdata), nlat, nlon))
-                    data[:, alats, alons] = ncdata[:, ilands]
-                    ncout.variables[var][:] = data
-                    for idx in range(len(xlands)):
-                        ncout.variables[var][:, idx // nlon, idx % nlon] = nc.variables[
-                            var
-                        ][:, ilands[idx]]
-                elif var == "nav_lat":
-                    ncout.variables[var][:] = pnavlat
-                elif var == "nav_lon":
-                    ncout.variables[var][:] = pnavlon
-                elif var == "lat":
-                    ncout.variables[var][:] = plat
-                elif var == "lon":
-                    ncout.variables[var][:] = plon
-                elif var == "contfrac":
-                    ncdata = nc.variables[var][:]
-                    data = np.ma.masked_all((nlat, nlon))
-                    data[alats, alons] = ncdata[ilats, ilons]
-                    ncout.variables[var][:] = data
-                else:
-                    ncout.variables[var][:] = nc.variables[var][:]
-            ncout.close()
-            nc.close()
-
-    # build aligned restart files
-    if mode == "aligned":
+    # ------------------------------
+    # Unstructured restart files
+    # ------------------------------
+    if mode == "unstructured":
         for path in varlist["restart"]:
-            print("Building aligned restart file for", path)
+            print("Building unstructured restart file for", path)
+    
             nc = Dataset(path)
-            ncout = Dataset(resultpath / os.path.split(path)[-1], "w")
+            outfile = str(resultpath / f"{os.path.basename(path).replace('.nc', '_unstructured.nc')}")
+            ncout = Dataset(outfile, "w")
+    
+            # ------------------------------
+            # Create dimensions
+            # ------------------------------
             for dim in nc.dimensions:
-                newsize = (
-                    len(plat)
-                    if dim in ["lat", "latitude", "y"]
-                    else (
-                        len(plon)
-                        if dim in ["lon", "longitude", "x"]
-                        else (
-                            None
-                            if nc.dimensions[dim].isunlimited()
-                            else len(nc.dimensions[dim])
-                        )
-                    )
-                )
-                ncout.createDimension(dim, newsize)
-            for var in nc.variables:
-                ncout.createVariable(
-                    var, nc.variables[var].dtype, nc.variables[var].dimensions
-                )
-                ncout.variables[var].setncatts(nc.variables[var].__dict__)
-                if var in ["nav_lat", "lat", "LAT", "latitude", "y"]:
-                    if len(nc.variables[var].dimensions) == 2:
-                        ncout.variables[var][:] = pnavlat
-                    else:
-                        ncout.variables[var][:] = plat
-                elif var in ["nav_lon", "lon", "LON", "longitude", "x"]:
-                    if len(nc.variables[var].dimensions) == 2:
-                        ncout.variables[var][:] = pnavlon
-                    else:
-                        ncout.variables[var][:] = plon
-                elif nc.variables[var].dimensions[-1] in [
-                    "lon",
-                    "longitude",
-                    "x",
-                ] and nc.variables[var].dimensions[-2] in ["lat", "latitude", "y"]:
-                    for idx in range(len(xlands)):
-                        ncout.variables[var][..., idx // nlon, idx % nlon] = (
-                            nc.variables[var][..., ilats[idx], ilons[idx]]
-                        )
+                if dim == "y":
+                    ncout.createDimension("y", len(ilats))  # number of unique pixels
+                elif dim == "x":
+                    ncout.createDimension("x", 1)
                 else:
-                    ncout.variables[var][:] = nc.variables[var][:]
+                    ncout.createDimension(dim, len(nc.dimensions[dim]) if not nc.dimensions[dim].isunlimited() else None)
+    
+            # ------------------------------
+            # Create variables
+            # ------------------------------
+            for var in nc.variables:
+                dims = list(nc.variables[var].dimensions)
+                dtype = nc.variables[var].dtype
+                fill_value = nc.variables[var]._FillValue if "_FillValue" in nc.variables[var].ncattrs() else None
+    
+                # Replace 'y' and 'x' dimensions
+                new_dims = ["y" if d == "y" else "x" if d == "x" else d for d in dims]
+    
+                if fill_value is not None:
+                    ncout.createVariable(var, dtype, new_dims, fill_value=fill_value)
+                else:
+                    ncout.createVariable(var, dtype, new_dims)
+    
+                # Copy variable attributes
+                ncout.variables[var].setncatts({
+                    k: v for k, v in nc.variables[var].__dict__.items() if k not in ["_FillValue", "missing_value"]
+                })
+    
+                # ------------------------------
+                # Assign data
+                # ------------------------------
+                data = nc.variables[var][:]
+                if "y" in dims and "x" in dims:
+                    # Find positions
+                    y_pos = dims.index("y")
+                    x_pos = dims.index("x")
+    
+                    # Prepare new array
+                    new_shape = list(data.shape)
+                    new_shape[y_pos] = len(ilats)
+                    new_shape[x_pos] = 1
+                    new_data = np.ma.masked_all(new_shape, dtype=dtype)
+    
+                    # Copy selected pixels
+                    for i, (ilat, ilon) in enumerate(zip(ilats, ilons)):
+                        idx_src = [slice(None)] * len(data.shape)
+                        idx_src[y_pos] = ilat
+                        idx_src[x_pos] = ilon
+    
+                        idx_dst = [slice(None)] * len(data.shape)
+                        idx_dst[y_pos] = i
+                        idx_dst[x_pos] = 0
+    
+                        new_data[tuple(idx_dst)] = data[tuple(idx_src)]
+    
+                    ncout.variables[var][:] = new_data
+                else:
+                    # Non-spatial or already compatible
+                    ncout.variables[var][:] = data
+    
             nc.close()
             ncout.close()
+   
+#    # build aligned forcing
+#    if mode == "aligned":
+#        nlat = int(np.ceil((len(IDx) / 2) ** 0.5))
+#        nlon = nlat * 2
+#        step = 180.0 / nlat
+#        plat = np.arange(90 - step / 2.0, -90, -step)
+#        plon = np.arange(-180 + step / 2.0, 180, step)
+#        pnavlon, pnavlat = np.meshgrid(plon, plat)
+#        alats = list()
+#        alons = list()
+#        for idx in range(len(xlands)):
+#            alats.append(idx // nlon)
+#            alons.append(idx % nlon)
+#        alats = np.array(alats)
+#        alons = np.array(alons)
+#        for year in range(
+#            varlist["climate"]["year_start"], varlist["climate"]["year_end"] + 1
+#        ):
+#            print("Building aligned forcing for year %s" % year)
+#            nc = Dataset(
+#                varlist["climate"]["sourcepath"]
+#                + varlist["climate"]["filename"]
+#                + str(year)
+#                + ".nc"
+#            )
+#            ncout = Dataset(resultpath / f"forcing_aligned_{year}.nc", "w")
+#
+#            for dim in nc.dimensions:
+#                if dim == "land":
+#                    continue
+#                newdim = (
+#                    "lon"
+#                    if dim in ["lon", "longitude", "x"]
+#                    else "lat"
+#                    if dim in ["lat", "latitude", "y"]
+#                    else dim
+#                )
+#                newsize = (
+#                    len(plat)
+#                    if newdim == "lat"
+#                    else (
+#                        len(plon)
+#                        if newdim == "lon"
+#                        else (
+#                            None
+#                            if nc.dimensions[dim].isunlimited()
+#                            else len(nc.dimensions[dim])
+#                        )
+#                    )
+#                )
+#                ncout.createDimension(newdim, newsize)
+#            for var in nc.variables:
+#                print(var)
+#                if var == "land":
+#                    continue
+#                elif (
+#                    len(nc.variables[var].dimensions) == 3
+#                    or "land" in nc.variables[var].dimensions
+#                ):
+#                    newdims = (nc.variables[var].dimensions[0], "lat", "lon")
+#                elif len(nc.variables[var].dimensions) == 2:
+#                    newdims = ("lat", "lon")
+#                elif nc.variables[var].dimensions[0] in ["lon", "longitude", "x"]:
+#                    newdims = ("lon",)
+#                elif nc.variables[var].dimensions[0] in ["lat", "latitude", "y"]:
+#                    newdims = ("lat",)
+#                else:
+#                    newdims = nc.variables[var].dimensions
+#                if len(newdims) > 2:
+#                    ncout.createVariable(
+#                        var,
+#                        nc.variables[var].dtype,
+#                        newdims,
+#                        fill_value=9.96921e36,
+#                        zlib=True,
+#                    )
+#                else:
+#                    ncout.createVariable(
+#                        var, nc.variables[var].dtype, newdims, fill_value=9.96921e36
+#                    )
+#                atts = dict()
+#                for key, value in nc.variables[var].__dict__.items():
+#                    if key not in ["_FillValue", "missing_value"]:
+#                        atts[key] = value
+#                ncout.variables[var].setncatts(atts)
+#                if len(nc.variables[var].dimensions) == 3:
+#                    ncdata = nc.variables[var][:]
+#                    data = np.ma.masked_all((len(ncdata), nlat, nlon))
+#                    data[:, alats, alons] = ncdata[:, ilats, ilons]
+#                    ncout.variables[var][:] = data
+#                    for idx in range(len(xlands)):
+#                        ncout.variables[var][:, idx // nlon, idx % nlon] = nc.variables[
+#                            var
+#                        ][:, ilats[idx], ilons[idx]]
+#                elif nc.variables[var].dimensions[-1] == "land":
+#                    ncdata = nc.variables[var][:]
+#                    data = np.ma.masked_all((len(ncdata), nlat, nlon))
+#                    data[:, alats, alons] = ncdata[:, ilands]
+#                    ncout.variables[var][:] = data
+#                    for idx in range(len(xlands)):
+#                        ncout.variables[var][:, idx // nlon, idx % nlon] = nc.variables[
+#                            var
+#                        ][:, ilands[idx]]
+#                elif var == "nav_lat":
+#                    ncout.variables[var][:] = pnavlat
+#                elif var == "nav_lon":
+#                    ncout.variables[var][:] = pnavlon
+#                elif var == "lat":
+#                    ncout.variables[var][:] = plat
+#                elif var == "lon":
+#                    ncout.variables[var][:] = plon
+#                elif var == "contfrac":
+#                    ncdata = nc.variables[var][:]
+#                    data = np.ma.masked_all((nlat, nlon))
+#                    data[alats, alons] = ncdata[ilats, ilons]
+#                    ncout.variables[var][:] = data
+#                else:
+#                    ncout.variables[var][:] = nc.variables[var][:]
+#            ncout.close()
+#            nc.close()
+#
+#    # build aligned restart files
+#    if mode == "aligned":
+#        for path in varlist["restart"]:
+#            print("Building aligned restart file for", path)
+#            nc = Dataset(path)
+#            ncout = Dataset(resultpath / os.path.split(path)[-1], "w")
+#            for dim in nc.dimensions:
+#                newsize = (
+#                    len(plat)
+#                    if dim in ["lat", "latitude", "y"]
+#                    else (
+#                        len(plon)
+#                        if dim in ["lon", "longitude", "x"]
+#                        else (
+#                            None
+#                            if nc.dimensions[dim].isunlimited()
+#                            else len(nc.dimensions[dim])
+#                        )
+#                    )
+#                )
+#                ncout.createDimension(dim, newsize)
+#            for var in nc.variables:
+#                ncout.createVariable(
+#                    var, nc.variables[var].dtype, nc.variables[var].dimensions
+#                )
+#                ncout.variables[var].setncatts(nc.variables[var].__dict__)
+#                if var in ["nav_lat", "lat", "LAT", "latitude", "y"]:
+#                    if len(nc.variables[var].dimensions) == 2:
+#                        ncout.variables[var][:] = pnavlat
+#                    else:
+#                        ncout.variables[var][:] = plat
+#                elif var in ["nav_lon", "lon", "LON", "longitude", "x"]:
+#                    if len(nc.variables[var].dimensions) == 2:
+#                        ncout.variables[var][:] = pnavlon
+#                    else:
+#                        ncout.variables[var][:] = plon
+#                elif nc.variables[var].dimensions[-1] in [
+#                    "lon",
+#                    "longitude",
+#                    "x",
+#                ] and nc.variables[var].dimensions[-2] in ["lat", "latitude", "y"]:
+#                    for idx in range(len(xlands)):
+#                        ncout.variables[var][..., idx // nlon, idx % nlon] = (
+#                            nc.variables[var][..., ilats[idx], ilons[idx]]
+#                        )
+#                else:
+#                    ncout.variables[var][:] = nc.variables[var][:]
+#            nc.close()
+#            ncout.close()

--- a/Tools/forcing.py
+++ b/Tools/forcing.py
@@ -291,7 +291,7 @@ def write(varlist, resultpath, IDx):
                 + str(year)
                 + ".nc"
             )
-            taset(resultpath / os.path.split(path)[-1], "w")
+            ncout = Dataset(resultpath / f"forcing_aligned_{year}.nc", "w")
 
             for dim in nc.dimensions:
                 if dim == "land":

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -249,7 +249,6 @@ def extrapolate_globally(
         ipft (int): Index of current Plant Functional Type.
         PFT_mask (numpy.ndarray): Mask for Plant Functional Types.
         combine_XY (pandas.DataFrame): DataFrame of input variables.
-        restvar (numpy.ndarray): Restart variable.
         missVal (float): Missing value to use.
         ind (tuple): Index tuple for multi-dimensional variables.
         col_type (str): Column name for encoding, or "None".

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -430,7 +430,7 @@ def ml_loop(
     print(rest_type)
 
     responseY = Dataset(sourcefile, "r")
-    print(responseY)
+    #print(responseY)
 
     PFT_mask, PFT_mask_lai = genmask.PFT(
         packdata, varlist, varlist["PFTmask"]["pred_thres"]
@@ -524,7 +524,7 @@ def ml_loop(
     rest_type = detect_grid_type(restfile)
     if rest_type != 'structured':
         raise RuntimeError("target file does not correspond to expected grid format 'structured' but is %f" % rest_type)
-    print(rest_type)
+    #print(rest_type)
 
     restnc = Dataset(restfile, "a")
     if rest_state:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -22,7 +22,6 @@ def remap_unstructured_to_structured(source_var, packdata, missVal=np.nan):
 
     source_var = np.asarray(source_var)
     n_cells = packdata.Nlat.size
-    print(n_cells)
 
     # Find axis corresponding to the cell dimension
     # Prefer the last dimension matching n_cells, as cell dimensions typically appear last.
@@ -579,7 +578,6 @@ def ml_loop(
         packdata = packdata.assign_attrs(cell_idx=cell_idx)
 
     responseY = Dataset(sourcefile, "r")
-    # print(responseY)
 
     PFT_mask, PFT_mask_lai = genmask.PFT(
         packdata, varlist, varlist["PFTmask"]["pred_thres"]
@@ -602,15 +600,12 @@ def ml_loop(
                 varname = jj + ("_%2.2i" % kk if kk else "") + ii["name_postfix"]
                 if ii["name_loop"] == "pft":
                     ipft = kk
-                #ivar = responseY[varname]
-                #ivar = responseY[varname][:].squeeze()
 
                 if rest_type == "unstructured":
                     ivar = remap_unstructured_to_structured(responseY[varname][:], packdata, missVal)
                 else:
                     ivar = responseY[varname]
 
-                print(varname, np.shape(ivar))
                 
                 if ii["dim_loop"] == ["null"] and ipft in ii["skip_loop"]["pft"]:
                     continue
@@ -681,7 +676,6 @@ def ml_loop(
         raise RuntimeError(
             f"target file does not correspond to expected grid format, but is {rest_type}"
         )
-    # print(rest_type)
 
     restnc = Dataset(restfile, "a")
     if rest_state:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -429,7 +429,6 @@ def ml_loop(
         raise RuntimeError(
             f"source file does not correspond to expected grid format, but is {rest_type}"
         )
-    print(rest_type)
 
     responseY = Dataset(sourcefile, "r")
     # print(responseY)

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -14,22 +14,153 @@
 
 from Tools import *
 
+def remap_unstructured_to_structured(source_var, packdata, missVal=np.nan):
+    """
+    Remap pseudo-unstructured variable to structured grid,
+    handling extra dimensions and cell dimension not at the last axis.
+    """
+
+    source_var = np.asarray(source_var)
+    n_cells = packdata.Nlat.size
+    print(n_cells)
+
+    # Find axis corresponding to the cell dimension
+    cell_axis = None
+    for ax, size in enumerate(source_var.shape):
+        if size == n_cells:
+            cell_axis = ax
+            break
+    if cell_axis is None:
+        raise RuntimeError(
+            f"Cannot find dimension matching n_cells={n_cells} in source_var.shape={source_var.shape}"
+        )
+
+    # Move the cell axis to the last position
+    if cell_axis != len(source_var.shape) - 1:
+        source_var = np.moveaxis(source_var, cell_axis, -1)
+
+    # Now the last dimension is the spatial cell dimension
+    structured_shape = source_var.shape[:-1] + (packdata.nlat, packdata.nlon)
+    structured = np.full(structured_shape, missVal, dtype=source_var.dtype)
+
+    # Flatten spatial indices
+    flat_idx = packdata.Nlat * packdata.nlon + packdata.Nlon
+    structured_flat = structured.reshape(*source_var.shape[:-1], -1)
+
+    # Assign cell values to global structured grid
+    structured_flat[..., flat_idx] = source_var[..., packdata.cell_idx]
+
+    # Reshape back to final structured shape
+    structured = structured_flat.reshape(structured_shape)
+    return structured
+
 
 def detect_grid_type(ncfile):
     """
     Detect whether a netCDF file is on a structured (lat/lon grid) or unstructured
     (cell-based) grid.
 
+    A file is considered unstructured if it has:
+    - a 'cell' dimension (true unstructured), OR
+    - a 'y' dimension with multiple cells and an 'x' dimension of size 1
+      (pseudo-unstructured, as produced by Step 3).
+
     Args:
         ncfile (str): Path to the netCDF file.
 
     Returns:
-        str: "unstructured" if the file has a 'cell' dimension, otherwise "structured".
+        str: "unstructured" if the file is in unstructured or pseudo-unstructured
+             format, otherwise "structured".
     """
     with Dataset(ncfile, "r") as nc:
         if "cell" in nc.dimensions:
             return "unstructured"
+        # Pseudo-unstructured: y dimension with multiple cells, x dimension of size 1
+        if (
+            "y" in nc.dimensions
+            and "x" in nc.dimensions
+            and len(nc.dimensions["x"]) == 1
+            and len(nc.dimensions["y"]) > 1
+        ):
+            return "unstructured"
     return "structured"
+
+
+def _build_cell_idx_map(sourcefile, packdata):
+    """
+    Build a mapping from training-pixel global-grid indices (Nlat, Nlon) to the
+    cell position in an unstructured source file.
+
+    The unstructured source file stores only a subset of pixels (the ones selected
+    during clustering).  This function reads the lat/lon coordinates stored in that
+    file, converts them to global-grid indices using the same formula used in
+    main.py for packdata.Nlat/Nlon, and returns an index array so that
+
+        pool_map.ravel()[cell_idx[j]]
+
+    gives the value that belongs to training pixel j (identified by
+    packdata.Nlat[j] / packdata.Nlon[j]).
+
+    Args:
+        sourcefile (str): Path to the unstructured source file.
+        packdata (xarray.Dataset): Dataset with attrs Nlat, Nlon, lat_reso, lon_reso.
+
+    Returns:
+        numpy.ndarray: Integer array of shape (len(packdata.Nlat),) with the cell
+            index in the source file for each training pixel.
+
+    Raises:
+        RuntimeError: If lat/lon coordinate variables cannot be found in the source
+            file, or if a training pixel is absent from the source file.
+    """
+    lat_names = ["nav_lat", "lat", "latitude"]
+    lon_names = ["nav_lon", "lon", "longitude"]
+
+    with Dataset(sourcefile, "r") as nc:
+        cell_lats = None
+        cell_lons = None
+        for name in lat_names:
+            if name in nc.variables:
+                cell_lats = np.squeeze(nc.variables[name][:])
+                break
+        for name in lon_names:
+            if name in nc.variables:
+                cell_lons = np.squeeze(nc.variables[name][:])
+                break
+
+    if cell_lats is None or cell_lons is None:
+        raise RuntimeError(
+            "Could not find lat/lon coordinate variables in unstructured source file"
+        )
+
+    # Convert cell lat/lon to global grid indices (same formula as in main.py)
+    cell_ilats = np.trunc((90 - cell_lats) / packdata.lat_reso).astype(int)
+    cell_ilons = np.trunc((180 + cell_lons) / packdata.lon_reso).astype(int)
+
+    # Build reverse mapping: (ilat, ilon) -> cell index in the source file
+    cell_map = {
+        (int(ilat), int(ilon)): i
+        for i, (ilat, ilon) in enumerate(
+            zip(cell_ilats.ravel(), cell_ilons.ravel())
+        )
+    }
+
+    # For each training pixel, look up its cell index in the source file
+    try:
+        cell_idx = np.array(
+            [
+                cell_map[(int(nlat), int(nlon))]
+                for nlat, nlon in zip(packdata.Nlat, packdata.Nlon)
+            ]
+        )
+    except KeyError as e:
+        raise RuntimeError(
+            f"Training pixel with global-grid index {e} was not found in the "
+            "unstructured source file. The source file may not contain all "
+            "training pixels."
+        ) from e
+
+    return cell_idx
 
 
 def mlmap_multidim(
@@ -212,9 +343,15 @@ def extract_data(packdata, ivar, ipft, PFT_mask_lai, varlist, labx, ind):
     pool_map[pool_map == 1e20] = np.nan
     # Y_map[ind[0]] = pool_map
 
-    if "format" in varlist["resp"] and varlist["resp"]["format"] == "compressed":
+    resp_format = varlist["resp"].get("format", "regular")
+    if resp_format == "compressed":
         pool_arr = pool_map.flatten()
-    else:
+    elif resp_format == "unstructured":
+    #    # pool_map is a flat 1-D array (n_cells,) from the unstructured source file.
+    #    # packdata.cell_idx maps each training pixel to its position in that array.
+    #    pool_arr = pool_map.ravel()[packdata.cell_idx]
+    #else:
+    #    # "regular" or any other structured format
         pool_arr = pool_map[packdata.Nlat, packdata.Nlon]
 
     extracted_Y = np.resize(pool_arr, (*extr_var.shape[:-1], 1))
@@ -425,10 +562,23 @@ def ml_loop(
 
     # check for grid type in source file
     rest_type = detect_grid_type(sourcefile)
-    if varlist["resp"]["format"] != rest_type:
+    # Map the varlist format name to the expected detected type.
+    # "regular" and "compressed" both correspond to a structured global grid;
+    # "unstructured" corresponds to either a true unstructured grid (cell dimension)
+    # or a pseudo-unstructured grid (y × x=1 layout produced by Step 3).
+    resp_format = varlist["resp"].get("format", "regular")
+    expected_type = "unstructured" if resp_format == "unstructured" else "structured"
+    if rest_type != expected_type:
         raise RuntimeError(
             f"source file does not correspond to expected grid format, but is {rest_type}"
         )
+
+    # For unstructured source files, build a mapping from the training-pixel
+    # global-grid indices (Nlat, Nlon) to the cell position in the source file,
+    # and store it as a packdata attribute so that extract_data can use it.
+    if rest_type == "unstructured":
+        cell_idx = _build_cell_idx_map(sourcefile, packdata)
+        packdata = packdata.assign_attrs(cell_idx=cell_idx)
 
     responseY = Dataset(sourcefile, "r")
     # print(responseY)
@@ -454,8 +604,16 @@ def ml_loop(
                 varname = jj + ("_%2.2i" % kk if kk else "") + ii["name_postfix"]
                 if ii["name_loop"] == "pft":
                     ipft = kk
-                ivar = responseY[varname]
+                #ivar = responseY[varname]
+                #ivar = responseY[varname][:].squeeze()
 
+                if rest_type == "unstructured":
+                    ivar = remap_unstructured_to_structured(responseY[varname][:], packdata, missVal)
+                else:
+                    ivar = responseY[varname]
+
+                print(varname, np.shape(ivar))
+                
                 if ii["dim_loop"] == ["null"] and ipft in ii["skip_loop"]["pft"]:
                     continue
                 else:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -14,6 +14,7 @@
 
 from Tools import *
 
+
 def remap_unstructured_to_structured(source_var, packdata, missVal=np.nan):
     """
     Remap pseudo-unstructured variable to structured grid,
@@ -137,9 +138,7 @@ def _build_cell_idx_map(sourcefile, packdata):
     # Build reverse mapping: (ilat, ilon) -> cell index in the source file
     cell_map = {
         (int(ilat), int(ilon)): i
-        for i, (ilat, ilon) in enumerate(
-            zip(cell_ilats.ravel(), cell_ilons.ravel())
-        )
+        for i, (ilat, ilon) in enumerate(zip(cell_ilats.ravel(), cell_ilons.ravel()))
     }
 
     # For each training pixel, look up its cell index in the source file
@@ -344,11 +343,6 @@ def extract_data(packdata, ivar, ipft, PFT_mask_lai, varlist, labx, ind):
     if resp_format == "compressed":
         pool_arr = pool_map.flatten()
     elif resp_format == "unstructured":
-    #    # pool_map is a flat 1-D array (n_cells,) from the unstructured source file.
-    #    # packdata.cell_idx maps each training pixel to its position in that array.
-    #    pool_arr = pool_map.ravel()[packdata.cell_idx]
-    #else:
-    #    # "regular" or any other structured format
         pool_arr = pool_map[packdata.Nlat, packdata.Nlon]
 
     extracted_Y = np.resize(pool_arr, (*extr_var.shape[:-1], 1))
@@ -602,11 +596,12 @@ def ml_loop(
                     ipft = kk
 
                 if rest_type == "unstructured":
-                    ivar = remap_unstructured_to_structured(responseY[varname][:], packdata, missVal)
+                    ivar = remap_unstructured_to_structured(
+                        responseY[varname][:], packdata, missVal
+                    )
                 else:
                     ivar = responseY[varname]
 
-                
                 if ii["dim_loop"] == ["null"] and ipft in ii["skip_loop"]["pft"]:
                     continue
                 else:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -546,7 +546,7 @@ def ml_loop(
         alg (str): ML algorithm to use.
         parallel (bool): Whether to run in parallel.
         model_out_dir (Path): Directory in which to save trained model output.
-        n_workers(int): Maximum CPUs available 
+        n_workers(int): Maximum CPUs available
         seed (int): Random seed to ensure reproducibility.
 
     Returns:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -14,6 +14,22 @@
 
 from Tools import *
 
+def detect_grid_type(ncfile):
+    """
+    Detect whether a netCDF file is on a structured (lat/lon grid) or unstructured
+    (cell-based) grid.
+
+    Args:
+        ncfile (str): Path to the netCDF file.
+
+    Returns:
+        str: "unstructured" if the file has a 'cell' dimension, otherwise "structured".
+    """
+    with Dataset(ncfile, "r") as nc:
+        if "cell" in nc.dimensions:
+            return "unstructured"
+    return "structured"
+
 
 def mlmap_multidim(
     packdata,
@@ -29,7 +45,6 @@ def mlmap_multidim(
     ii,
     leave_one_out_cv,
     smote_bat,
-    restvar,
     missVal,
     alg,
     model_out_dir,
@@ -128,7 +143,6 @@ def mlmap_multidim(
         ipft,
         PFT_mask,
         combine_XY,
-        restvar,
         missVal,
         ind,
         col_type,
@@ -218,7 +232,6 @@ def extrapolate_globally(
     ipft,
     PFT_mask,
     combine_XY,
-    restvar,
     missVal,
     ind,
     col_type,
@@ -262,7 +275,7 @@ def extrapolate_globally(
         )
         # Modify restart file with extrapolated values
         pmask = np.nansum(PFT_mask, axis=0)
-        pmask[np.isnan(pmask)] == 0
+        pmask[np.isnan(pmask)] = 0
         # Set ocean pixel to missVal
         Pred_Y_out = np.where(pmask == 0, missVal, Global_Predicted_Y_map[:])
         # some pixel with nan remain, so set them zero
@@ -383,6 +396,7 @@ def ml_loop(
     labx,
     config,
     restfile,
+    sourcefile,
     alg,
     parallel,
     model_out_dir,
@@ -398,7 +412,8 @@ def ml_loop(
         varlist (dict): Dictionary of variable information.
         labx (list): List of column labels.
         config (module): module of config.
-        restfile (str): Path to restart file.
+        restfile (str): Path to restart file ( global structured grid )
+        sourcefile (str): Path to restart file with training data ( grid type can vary )
         alg (str): ML algorithm to use.
         parallel (bool): Whether to run in parallel.
         save_model (bool): Option to save trained model output.
@@ -407,7 +422,16 @@ def ml_loop(
     Returns:
         pandas.DataFrame: Results of machine learning evaluations.
     """
-    responseY = Dataset(varlist["resp"]["sourcefile"], "r")
+
+    # check for grid type in source file
+    rest_type = detect_grid_type(sourcefile)
+    if varlist["resp"]["format"] == rest_type:
+        raise RuntimeError("source file does not correspond to expected grid format %f" % rest_type)
+    print(rest_type)
+
+    responseY = Dataset(sourcefile, "r")
+    print(responseY)
+
     PFT_mask, PFT_mask_lai = genmask.PFT(
         packdata, varlist, varlist["PFTmask"]["pred_thres"]
     )
@@ -416,10 +440,9 @@ def ml_loop(
 
     inputs = []
 
-    # Open restart file and select variable
+    # Open restart file with the training data and select variables
     # - old comment suggested that memory was exceeded outside loop
 
-    restnc = Dataset(restfile, "a")
     result = []
 
     Yvar = varlist["resp"]["variables"][ipool]
@@ -432,7 +455,6 @@ def ml_loop(
                     ipft = kk
                 ivar = responseY[varname]
 
-                restvar = restnc[varname]
 
                 if ii["dim_loop"] == ["null"] and ipft in ii["skip_loop"]["pft"]:
                     continue
@@ -446,7 +468,6 @@ def ml_loop(
                             ipft = ind[ii["dim_loop"].index("pft")]
                         if ipft in ii["skip_loop"]["pft"]:
                             continue
-                        # inputs.append(
                         inputs.append(
                             (
                                 packdata,
@@ -462,7 +483,6 @@ def ml_loop(
                                 ii,
                                 config.leave_one_out_cv,
                                 config.smote_bat,
-                                restvar[:],
                                 missVal,
                                 alg,
                                 str(model_out_dir),
@@ -472,7 +492,6 @@ def ml_loop(
 
     # Close files
     responseY.close()
-    restnc.close()
 
     # # Run the MLmap_multidim function in parallel or serial
     if parallel:
@@ -498,7 +517,14 @@ def ml_loop(
                     all_result.append(result)
                     rest_state.append((varname, idx, Pred_Y_out))
 
-    # Modify restart file
+    # Modify restart file ( global structured grid )
+
+
+    # check for grid type in source file
+    rest_type = detect_grid_type(restfile)
+    if rest_type != 'structured':
+        raise RuntimeError("target file does not correspond to expected grid format 'structured' but is %f" % rest_type)
+    print(rest_type)
 
     restnc = Dataset(restfile, "a")
     if rest_state:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -425,9 +425,9 @@ def ml_loop(
 
     # check for grid type in source file
     rest_type = detect_grid_type(sourcefile)
-    if varlist["resp"]["format"] == rest_type:
+    if varlist["resp"]["format"] != rest_type:
         raise RuntimeError(
-            "source file does not correspond to expected grid format %f" % rest_type
+            f"source file does not correspond to expected grid format, but is {rest_type}"
         )
     print(rest_type)
 
@@ -524,8 +524,7 @@ def ml_loop(
     rest_type = detect_grid_type(restfile)
     if rest_type != "structured":
         raise RuntimeError(
-            "target file does not correspond to expected grid format 'structured' but is %f"
-            % rest_type
+            f"target file does not correspond to expected grid format, but is {rest_type}"
         )
     # print(rest_type)
 

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -416,7 +416,7 @@ def ml_loop(
         sourcefile (str): Path to restart file with training data ( grid type can vary )
         alg (str): ML algorithm to use.
         parallel (bool): Whether to run in parallel.
-        save_model (bool): Option to save trained model output.
+        model_out_dir (Path): Directory in which to save trained model output.
         seed (int): Random seed to ensure reproducibility.
 
     Returns:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -25,15 +25,13 @@ def remap_unstructured_to_structured(source_var, packdata, missVal=np.nan):
     print(n_cells)
 
     # Find axis corresponding to the cell dimension
-    cell_axis = None
-    for ax, size in enumerate(source_var.shape):
-        if size == n_cells:
-            cell_axis = ax
-            break
-    if cell_axis is None:
+    # Prefer the last dimension matching n_cells, as cell dimensions typically appear last.
+    matching_axes = [ax for ax, size in enumerate(source_var.shape) if size == n_cells]
+    if not matching_axes:
         raise RuntimeError(
             f"Cannot find dimension matching n_cells={n_cells} in source_var.shape={source_var.shape}"
         )
+    cell_axis = matching_axes[-1]
 
     # Move the cell axis to the last position
     if cell_axis != len(source_var.shape) - 1:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -14,6 +14,7 @@
 
 from Tools import *
 
+
 def detect_grid_type(ncfile):
     """
     Detect whether a netCDF file is on a structured (lat/lon grid) or unstructured
@@ -426,11 +427,13 @@ def ml_loop(
     # check for grid type in source file
     rest_type = detect_grid_type(sourcefile)
     if varlist["resp"]["format"] == rest_type:
-        raise RuntimeError("source file does not correspond to expected grid format %f" % rest_type)
+        raise RuntimeError(
+            "source file does not correspond to expected grid format %f" % rest_type
+        )
     print(rest_type)
 
     responseY = Dataset(sourcefile, "r")
-    #print(responseY)
+    # print(responseY)
 
     PFT_mask, PFT_mask_lai = genmask.PFT(
         packdata, varlist, varlist["PFTmask"]["pred_thres"]
@@ -454,7 +457,6 @@ def ml_loop(
                 if ii["name_loop"] == "pft":
                     ipft = kk
                 ivar = responseY[varname]
-
 
                 if ii["dim_loop"] == ["null"] and ipft in ii["skip_loop"]["pft"]:
                     continue
@@ -519,12 +521,14 @@ def ml_loop(
 
     # Modify restart file ( global structured grid )
 
-
     # check for grid type in source file
     rest_type = detect_grid_type(restfile)
-    if rest_type != 'structured':
-        raise RuntimeError("target file does not correspond to expected grid format 'structured' but is %f" % rest_type)
-    #print(rest_type)
+    if rest_type != "structured":
+        raise RuntimeError(
+            "target file does not correspond to expected grid format 'structured' but is %f"
+            % rest_type
+        )
+    # print(rest_type)
 
     restnc = Dataset(restfile, "a")
     if rest_state:

--- a/Tools/ml.py
+++ b/Tools/ml.py
@@ -528,6 +528,7 @@ def ml_loop(
     alg,
     parallel,
     model_out_dir,
+    n_workers,
     seed,
 ):
     """
@@ -545,6 +546,7 @@ def ml_loop(
         alg (str): ML algorithm to use.
         parallel (bool): Whether to run in parallel.
         model_out_dir (Path): Directory in which to save trained model output.
+        n_workers(int): Maximum CPUs available 
         seed (int): Random seed to ensure reproducibility.
 
     Returns:
@@ -641,7 +643,7 @@ def ml_loop(
 
     # # Run the MLmap_multidim function in parallel or serial
     if parallel:
-        with ProcessPoolExecutor() as executor:
+        with ProcessPoolExecutor(max_workers=n_workers) as executor:
             # Call the MLmap_multidim function with the arguments in inputs
             # Inputs is a list of tuples, each tuple is the arguments for the function
             # All inputs are collected in the result list

--- a/Tools/train.py
+++ b/Tools/train.py
@@ -278,7 +278,7 @@ def training_bat(
         loocv_dNRMSE = loocv_RMSE / (np.max(ytests) - np.min(ytests))
         loocv_sNRMSE = loocv_RMSE / np.std(ytests)
         loocv_iNRMSE = loocv_RMSE / (
-            np.quantile(ytests, 0.75) - np.quantile(ytests, 0.75)
+            np.quantile(ytests, 0.75) - np.quantile(ytests, 0.25)
         )
         loocv_f_SB = (np.mean(ypreds - ytests)) ** 2 / loocv_MSE
         loocv_f_SDSD = (np.std(ytests) - np.std(ypreds)) ** 2 / loocv_MSE

--- a/Tools/train.py
+++ b/Tools/train.py
@@ -241,7 +241,7 @@ def training_bat(
 
     try:
         model.fit(Xtrain, Ytrain, estimator__sample_weight=SW)
-    except TypeError:
+    except (TypeError, ValueError):
         model.fit(Xtrain, Ytrain)
 
     # predict
@@ -261,7 +261,12 @@ def training_bat(
             X_train, X_test = XM[train_idx, :], XM[test_idx, :]
             y_train, y_test = YM[train_idx], YM[test_idx]
             SW_train = SW[train_idx]
-            model.fit(X_train, y_train, sample_weight=SW_train)
+
+            try:
+                model.fit(X_train, y_train, estimator__sample_weight=SW_train)
+            except (TypeError, ValueError):
+                model.fit(X_train, y_train)
+
             y_pred = model.predict(X_test)
             ytests += list(y_test)
             ypreds += list(y_pred)
@@ -331,7 +336,7 @@ def select_best_model(X, Y, estimators, SW):
         )
         try:
             model.fit(Xtrain, Ytrain, estimator__sample_weight=SWtrain)
-        except TypeError:
+        except (TypeError, ValueError):
             model.fit(Xtrain, Ytrain)
         Ypred = model.predict(Xval)
         scores.append(r2_score(Yval, Ypred))

--- a/jobs/DEF_CNP/varlist.json
+++ b/jobs/DEF_CNP/varlist.json
@@ -65,6 +65,8 @@
   "resp":
   {
     "sourcefile":"/home/satellites8/ylwang/MLacc/forcing_var/ORCHIDEECNP/gcp.r5986.twodeg.trendyv9.CNP01cc0.rrn.ORI000.clim3_77081231_stomate_rest.nc",
+    "targetfile":"/home/satellites8/ylwang/MLacc/forcing_var/ORCHIDEECNP/gcp.r5986.twodeg.trendyv9.CNP01cc0.rrn.ORI000.clim3_77081231_stomate_rest.nc",
+    "format":"regular",
     "missing_value":1e20,
     "pool_name_som":["Active","Passive","Slow","Surface"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Carbres","Labile"],

--- a/jobs/DEF_CNP2/config.py
+++ b/jobs/DEF_CNP2/config.py
@@ -30,7 +30,6 @@ model_out = False  # Optional
 parallel = False  # True by default
 sel_most_PFT_sites = False
 old_cluster = True  # True by default
-# obsolete take_unique = True
 
 # Output and testing
 results_dir = "./EXE_DIR_CNP2.TEST.UNIQUE/"

--- a/jobs/DEF_CNP2/config.py
+++ b/jobs/DEF_CNP2/config.py
@@ -1,0 +1,42 @@
+"""Configuration file for the MLacc tasks."""
+
+logfile = "log.MLacc_CNP2"
+tasks = [
+#    1,
+#    2,
+#    3,
+    4,
+#    5,
+]  # 1=test clustering, 2=clustering, 3=compress forcing, 4=ML, 5=evaluation
+
+kmeans_clusters = 4
+max_kmeans_clusters = 9
+random_seed = 1000
+algorithms = [
+    "bt",
+    # "rf",
+    # "gbm",
+    # "nn",
+    # "ridge",
+    # "best",
+]  # bt: BaggingTrees, rf: RandomForest, nn: MLPRegressor, gbm: XGBRegressor, lasso: Lasso, best: SelectBestModel
+
+start_from_scratch = False
+
+# To modify:
+take_year_average = False  # Performance improved when set to True
+smote_bat = True
+model_out = False  # Optional
+parallel = False  # True by default
+sel_most_PFT_sites = False
+old_cluster = True  # True by default
+# obsolete take_unique = True
+
+# Output and testing
+results_dir = "./EXE_DIR_CNP2.TEST.UNIQUE/"
+reference_dir = "./SPINacc-results/"
+leave_one_out_cv = False
+repro_test_task_1 = False
+repro_test_task_2 = False
+repro_test_task_3 = False
+repro_test_task_4 = False

--- a/jobs/DEF_CNP2/varlist.json
+++ b/jobs/DEF_CNP2/varlist.json
@@ -1,19 +1,19 @@
 {
 
-  "coord_ref":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_stomate_rest.nc",
+  "coord_ref":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13501231_stomate_rest.nc",
   "lat_reso":2,
   "lon_reso":2,
   "climate":
   {
-    "sourcepath":"/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2/twodeg/",
-    "filename":"crujra_twodeg_v2.2_",
+    "sourcepath":"/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2.2/twodeg/",
+    "filename":"crujra_twodeg_v2.2.2_",
     "year_start":1901,
     "year_end":1920,
     "variables":["Tair","Rainf","Snowf","Qair","PSurf","SWdown","LWdown"]
   },
   "PFTmask":
   {
-    "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13000101_13001231_1M_stomate_history.nc",
+    "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13500101_13501231_1M_stomate_history.nc",
     "var":"VEGET_COV_MAX",
     "cluster_thres":0.001,
     "pred_thres":0.001
@@ -22,26 +22,26 @@
   {
     "var1":
     {
-      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13000101_13001231_1M_stomate_history.nc",
+      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13500101_13501231_1M_stomate_history.nc",
       "variables":["NPP","LAI"],
       "rename":["NPP0","LAI0"]
     },
     "var2":
     {
-      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_stomate_rest.nc",
+      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13501231_stomate_rest.nc",
       "variables":["soil_orders","soil_shield"],
       "missing_value":1e20
 
     },
     "var3":
     {
-      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SRF/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_sechiba_rest.nc",
+      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SRF/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13501231_sechiba_rest.nc",
       "variables":["clay_frac","silt_frac","bulk","soil_ph"],
       "missing_value":1e20
     },
     "var4":
     {
-      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13000101_13001231_1M_stomate_history.nc",
+      "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Output/MO/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13500101_13501231_1M_stomate_history.nc",
       "variables":["NHX_DEPOSITION","NOY_DEPOSITION","P_DEPOSITION"],
       "rename":["Ndep_nhx","Ndep_noy","Pdep"],
       "missing_value":1e20
@@ -64,9 +64,9 @@
   },
   "resp":
   {
-    "format": "compressed",
-    "sourcefile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_MLA/CNP13.global.halfdeg.trendyv10.spinup.1700.compressed/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.compressed_60001231_stomate_rest.nc",
-    "targetfile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_stomate_rest.nc",
+    "sourcefile":"EXE_DIR/SBGRESTART_UNSTRUCTURED",
+    "targetfile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13501231_stomate_rest.nc",
+    "format":"unstructured",
     "missing_value":1e20,
     "pool_name_som":["Active","ChemProtect","PhysProtect"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Carbres","Labile"],
@@ -395,12 +395,16 @@
       ]
     }
   },
-  "restart": ["/home/surface3/hzhang/NPdep/Ndep_Pdep_Trendy2019_final_input_halfdeg_1700.nc",
-              "/home/surface3/hzhang/NPdep/NMIP_NP_agricultural_input_halfdeg_1700.nc",
-              "/home/surface7/jchang/input_cnp/CNP_files/rev01/lithology.nc",
-              "/home/surface7/jchang/input_cnp/CNP_files/rev01/soils_param.nc",
-              "/home/surface7/jchang/input_cnp/CNP_files/rev01/USDA_SoilSuborder.nc",
+  "restart": ["/home/surface10/common/CNP_files/rev01/USDA_SoilSuborder.nc",
+              "/home/surface10/common/CNP_files/rev01/soils_param.nc",
+              "/home/surface10/common/CNP_files/rev01/lithology.nc",
+              "/home/surface10/common/CNP_files/NPdep/Ndep_Pdep_Trendy2019_final_input_halfdeg_1700.nc",
+              "/home/surface10/common/CNP_files/NPdep/NMIP_NP_agricultural_input_halfdeg_1700.nc",
               "/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/OOL/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_driver_rest.nc",
               "/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SRF/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_sechiba_rest.nc",
               "/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700_13001231_stomate_rest.nc"]
 }
+
+
+
+

--- a/jobs/DEF_CNP2/varlist.json
+++ b/jobs/DEF_CNP2/varlist.json
@@ -64,7 +64,7 @@
   },
   "resp":
   {
-    "sourcefile":"EXE_DIR/SBGRESTART_UNSTRUCTURED",
+    "sourcefile":"/home/surface11/dgoll/IGCM_OUT/OL2/PROD/CNP_SPINacc/SPINacc.twodeg.newdriver.1700.unstructured.sites.restart/SBG/Restart/SPINacc.twodeg.newdriver.1700.unstructured.sites.restart_13001231_stomate_rest.nc",
     "targetfile":"/home/surface10/dgoll/IGCM_OUT/OL2/PROD/CNP_CUE/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300/SBG/Restart/CNP13.global.halfdeg.trendyv10.spinup.1700.year1300_13501231_stomate_rest.nc",
     "format":"unstructured",
     "missing_value":1e20,

--- a/jobs/DEF_MICT/varlist.json
+++ b/jobs/DEF_MICT/varlist.json
@@ -51,6 +51,8 @@
   "resp":
   {
     "sourcefile":"/home/surface3/dgoll/SPINUP_ML/TEST_DATA/MICT/MICT-CRUJRAv2_for_Yan_MLtaskforce/firemip.spin5.equil2_15001231_stomate_rest.nc",
+    "targetfile":"/home/surface3/dgoll/SPINUP_ML/TEST_DATA/MICT/MICT-CRUJRAv2_for_Yan_MLtaskforce/firemip.spin5.equil2_15001231_stomate_rest.nc",
+    "format":"regular",
     "missing_value":1e20,
     "pool_name_som":["L01","L02","L03","L04","L05","L06","L07","L08","L09","L10","L11","L12","L13","L14","L15","L16","L17","L18","L19","L20","L21","L22","L23","L24","L25","L26","L27","L28","L29","L30","L31","L32"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Labile"],

--- a/jobs/DEF_Trunk/config.py
+++ b/jobs/DEF_Trunk/config.py
@@ -1,12 +1,12 @@
 """Configuration file for the MLacc tasks."""
 
-logfile = "log.MLacc_Trunk"
+logfile = "log.MLacc_Trunk.ORCv22"
 tasks = [
-    1,
-    2,
-    # 3,
+#    1,
+#    2,
+#    3,
     4,
-    5,
+#    5,
 ]  # 1=test clustering, 2=clustering, 3=compress forcing, 4=ML, 5=evaluation
 
 kmeans_clusters = 4
@@ -27,10 +27,9 @@ start_from_scratch = False
 take_year_average = False  # Performance improved when set to True
 smote_bat = True
 model_out = False  # Optional
-parallel = True  # True by default
+parallel = True # True by default
 sel_most_PFT_sites = False
 old_cluster = True  # True by default
-take_unique = False
 
 # Output and testing
 results_dir = "./EXE_DIR/"

--- a/jobs/DEF_Trunk/varlist.json
+++ b/jobs/DEF_Trunk/varlist.json
@@ -1,6 +1,6 @@
 {
 
-  "coord_ref":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
+  "coord_ref":"/home/surface5/vbastri/SPINacc_ref/10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
   "lat_reso":2,
   "lon_reso":2,
   "climate":
@@ -13,7 +13,7 @@
   },
   "PFTmask":
   {
-    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
+    "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
     "var":"VEGET_COV_MAX",
     "cluster_thres":0.001,
     "pred_thres":0.1
@@ -22,13 +22,13 @@
   {
     "var1":
     {
-      "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
+      "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
       "variables":["NPP","LAI"],
       "rename":["NPP0","LAI0"]
     },
     "var2":
     {
-      "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
+      "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
       "variables":["clay_frac"],
       "missing_value":1e20
     },
@@ -48,9 +48,9 @@
   },
   "resp":
   {
-    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/EXE_DIR/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest_unstructured.nc",
-    "targetfile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
-    "format":"unstructured",
+    "sourcefile":"/home/surface5/vbastri/SPINacc_ref/GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc",
+    "targetfile":"/home/surface5/vbastri/SPINacc_ref/GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc",
+    "format":"structured",
     "missing_value":1e20,
     "pool_name_som":["Active","Passive","Slow"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Labile"],
@@ -139,8 +139,8 @@
       ]
     }
   },
-  "restart": [ "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/OOL_FGSPIN.10Y.ORC22v8034_19101231_driver_rest.nc",
-              "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
-              "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc"   ]
+  "restart": [ "/home/surface5/vbastri/SPINacc_ref/10Y/OOL_FGSPIN.10Y.ORC22v8034_19101231_driver_rest.nc",
+              "/home/surface5/vbastri/SPINacc_ref/10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
+              "/home/surface5/vbastri/SPINacc_ref/10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc"   ]
 
 }

--- a/jobs/DEF_Trunk/varlist.json
+++ b/jobs/DEF_Trunk/varlist.json
@@ -50,7 +50,7 @@
   {
     "sourcefile":"/home/surface5/vbastri/SPINacc_ref/GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc",
     "targetfile":"/home/surface5/vbastri/SPINacc_ref/GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc",
-    "format":"structured",
+    "format":"regular",
     "missing_value":1e20,
     "pool_name_som":["Active","Passive","Slow"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Labile"],

--- a/jobs/DEF_Trunk/varlist.json
+++ b/jobs/DEF_Trunk/varlist.json
@@ -48,9 +48,9 @@
   },
   "resp":
   {
-    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/EXE_DIR/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest_unstructured.nc_INPUTSTP4",
+    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/EXE_DIR/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest_unstructured.nc",
     "targetfile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
-    "mode":"unstructured",
+    "format":"unstructured",
     "missing_value":1e20,
     "pool_name_som":["Active","Passive","Slow"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Labile"],

--- a/jobs/DEF_Trunk/varlist.json
+++ b/jobs/DEF_Trunk/varlist.json
@@ -1,19 +1,19 @@
 {
 
-  "coord_ref":"/home/surface5/vbastri/SPINacc_ref/10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
+  "coord_ref":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
   "lat_reso":2,
   "lon_reso":2,
   "climate":
   {
-    "sourcepath":"/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2/twodeg/",
-    "filename":"crujra_twodeg_v2.2_",
+    "sourcepath":"/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2.2/twodeg/",
+    "filename":"crujra_twodeg_v2.2.2_",
     "year_start":1901,
     "year_end":1910,
     "variables":["Tair","Rainf","Snowf","Qair","PSurf","SWdown","LWdown"]
   },
   "PFTmask":
   {
-    "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
+    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
     "var":"VEGET_COV_MAX",
     "cluster_thres":0.001,
     "pred_thres":0.1
@@ -22,13 +22,13 @@
   {
     "var1":
     {
-      "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
+      "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/FGSPIN.10Y.ORC22v8034_19010101_19101231_1Y_stomate_history.nc",
       "variables":["NPP","LAI"],
       "rename":["NPP0","LAI0"]
     },
     "var2":
     {
-      "sourcefile":"/home/surface5/vbastri/SPINacc_ref/10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
+      "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
       "variables":["clay_frac"],
       "missing_value":1e20
     },
@@ -48,7 +48,9 @@
   },
   "resp":
   {
-    "sourcefile":"/home/surface5/vbastri/SPINacc_ref/GLOBAL340Y/SBG_FGSPIN.340Y.ORC22v8034_22501231_stomate_rest.nc",
+    "sourcefile":"/home/surface11/dgoll/20260220/SPINacc/EXE_DIR/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest_unstructured.nc_INPUTSTP4",
+    "targetfile":"/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc",
+    "mode":"unstructured",
     "missing_value":1e20,
     "pool_name_som":["Active","Passive","Slow"],
     "pool_name_biomass":["Leaf","SapAB","SapBE","HeartAB","HeartBE","Root","Fruit","Labile"],
@@ -137,8 +139,8 @@
       ]
     }
   },
-  "restart": [ "/home/surface5/vbastri/SPINacc_ref/10Y/OOL_FGSPIN.10Y.ORC22v8034_19101231_driver_rest.nc",
-              "/home/surface5/vbastri/SPINacc_ref/10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
-              "/home/surface5/vbastri/SPINacc_ref/10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc"   ]
+  "restart": [ "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/OOL_FGSPIN.10Y.ORC22v8034_19101231_driver_rest.nc",
+              "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SRF_FGSPIN.10Y.ORC22v8034_19101231_sechiba_rest.nc",
+              "/home/surface11/dgoll/20260220/SPINacc/ORCHIDEE_forcing_data/vlad_files/vlad_files//10Y/SBG_FGSPIN.10Y.ORC22v8034_19101231_stomate_rest.nc"   ]
 
 }

--- a/jobs/obelix/job
+++ b/jobs/obelix/job
@@ -1,7 +1,8 @@
 #PBS -eo
-#PBS -l ncpus=4
 #PBS -S /bin/tcsh
-#
+##PBS -l ncpus=4
+##PBS -l walltime=01:00:00
+##PBS -N my_job
 
 # Set the dirpython environment variable to the directory in which this script is located
 setenv dirpython '/home/surface11/dgoll/20260220/SPINacc'

--- a/jobs/obelix/job
+++ b/jobs/obelix/job
@@ -1,11 +1,13 @@
 #PBS -eo
+#PBS -l ncpus=4
 #PBS -S /bin/tcsh
+#
 
 # Set the dirpython environment variable to the directory in which this script is located
-setenv dirpython `pwd`
+setenv dirpython '/home/surface11/dgoll/20260220/SPINacc'
 
 # Set the dirdef environment variable to the string 'DEF_CNP2/'
-setenv dirdef 'DEF_CNP2/'
+setenv dirdef 'jobs/DEF_Trunk/'
 
 # Increase the maximum number of file descriptors that the process can open
 limit descriptors 10000

--- a/main.py
+++ b/main.py
@@ -264,8 +264,6 @@ def main():
         os.system("cp -f %s %s" % (targetfile, restfile))
 
         sourcefile = varlist["resp"]["sourcefile"]
-        sourcefile = resultpath / sourcefile.split("/")[-1]
-
 
         #
         # Add rights to manipulate file:

--- a/main.py
+++ b/main.py
@@ -211,7 +211,7 @@ def main():
             )
         check.display("Task 2: done", logfile)
 
-    # Task 3: Build aligned forcing and aligned restart files (optional)
+    # Task 3: Build forcing and restart files
     if "3" in itask:
         check.check_file(resultpath / "IDx.npy", logfile)
         IDx = np.load(resultpath / "IDx.npy", allow_pickle=True)
@@ -258,22 +258,28 @@ def main():
             Nlon=np.trunc((180 + IDx[:, 1]) / packdata.lon_reso).astype(int),
         )
         labx = ["Y"] + list(packdata.data_vars) + ["pft"]
-        # labx = ["Y"] + var_pred_name + ["pft"]
-        # Copy the restart file to be modified
-        targetfile = (
-            varlist["resp"]["targetfile"]
-            if "targetfile" in varlist["resp"]
-            else varlist["resp"]["sourcefile"]
-        )
+
+        #if varlist["resp"].get("mode") == "unstructured":
+        #    if "targetfile" in varlist["resp"]:
+        #        targetfile = varlist["resp"]["targetfile"]
+        #    else:
+        #        raise KeyError("Mode is 'unstructured' but 'targetfile' is missing in varlist['resp']")
+        #else:
+        #    raise ValueError(f"Unsupported mode: {varlist['resp'].get('mode')}")
+
+        targetfile = varlist["resp"]["targetfile"]
         restfile = resultpath / targetfile.split("/")[-1]
         os.system("cp -f %s %s" % (targetfile, restfile))
+
+        #
         # Add rights to manipulate file:
         os.chmod(restfile, 0o644)
 
         for alg in config.algorithms:
             result = []
             for ipool in Yvar.keys():
-                check.display("processing %s..." % ipool, logfile)
+                check.display("main.py: processing %s..." % ipool, logfile)
+
                 res_df = ml.ml_loop(
                     packdata,
                     ipool,

--- a/main.py
+++ b/main.py
@@ -272,7 +272,7 @@ def main():
         os.system("cp -f %s %s" % (targetfile, restfile))
 
         sourcefile = varlist["resp"]["sourcefile"]
-        sourcefile = resultpath / targetfile.split("/")[-1]
+        sourcefile = resultpath / sourcefile.split("/")[-1]
 
 
         #

--- a/main.py
+++ b/main.py
@@ -108,11 +108,6 @@ def main():
         if model_out:
             model_out_dir = resultpath / "model_output"
 
-    # Read take_unique setting in config
-    take_unique = True
-    if hasattr(config, "take_unique"):
-        take_unique = config.take_unique
-
     # Read the set_most_PFT_sites from the config (False by default)
     sel_most_PFT_sites = False
     if hasattr(config, "sel_most_PFT_sites"):
@@ -175,7 +170,6 @@ def main():
             varlist,
             K,
             logfile,
-            take_unique,
             sel_most_PFT_sites,
             old_cluster,
             iseed,

--- a/main.py
+++ b/main.py
@@ -271,6 +271,10 @@ def main():
         restfile = resultpath / targetfile.split("/")[-1]
         os.system("cp -f %s %s" % (targetfile, restfile))
 
+        sourcefile = varlist["resp"]["sourcefile"]
+        sourcefile = resultpath / targetfile.split("/")[-1]
+
+
         #
         # Add rights to manipulate file:
         os.chmod(restfile, 0o644)
@@ -288,6 +292,7 @@ def main():
                     labx,
                     config,
                     restfile,
+                    sourcefile,
                     alg,
                     parallel,
                     model_out_dir,

--- a/main.py
+++ b/main.py
@@ -23,13 +23,33 @@ This software is governed by the XXX license
 XXXX <License content>
 """
 
+## tested on obelix architecture 
+import os
+# Force 1 thread per worker
+os.environ['OMP_NUM_THREADS'] = '1'
+os.environ['MKL_NUM_THREADS'] = '1'
+os.environ['OPENBLAS_NUM_THREADS'] = '1'
+os.environ['NUMEXPR_NUM_THREADS'] = '1'
+
+# Determine CPUs allocated by PBS
+if 'PBS_NODEFILE' in os.environ:
+    with open(os.environ['PBS_NODEFILE']) as f:
+        total_cpus = len(f.readlines())
+else:
+    total_cpus = 1
+# Use all allocated CPUs
+n_workers = total_cpus
+print("PBS allocated CPUs:", total_cpus)
+print("Number of maximum workers (processes):", n_workers)
+## obelix 
+
+
 from Tools import *
 
 import numpy as np
 import xarray
 import subprocess
 import multiprocessing
-
 
 def main():
     # Print Python version
@@ -280,6 +300,7 @@ def main():
                     alg,
                     parallel,
                     model_out_dir,
+                    n_workers,
                     seed=iseed,
                 )
                 result.append(res_df)

--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ def main():
         old_cluster = config.old_cluster
 
     # if sel_most_PFT_sites is set to True and old_cluster is set to True, raise an error
-    if sel_most_PFT_sites and not old_cluster:
+    if sel_most_PFT_sites and old_cluster:
         raise ValueError(
             "sel_most_PFT_sites and old_cluster cannot be set to True at the same time"
         )

--- a/main.py
+++ b/main.py
@@ -259,14 +259,6 @@ def main():
         )
         labx = ["Y"] + list(packdata.data_vars) + ["pft"]
 
-        #if varlist["resp"].get("mode") == "unstructured":
-        #    if "targetfile" in varlist["resp"]:
-        #        targetfile = varlist["resp"]["targetfile"]
-        #    else:
-        #        raise KeyError("Mode is 'unstructured' but 'targetfile' is missing in varlist['resp']")
-        #else:
-        #    raise ValueError(f"Unsupported mode: {varlist['resp'].get('mode')}")
-
         targetfile = varlist["resp"]["targetfile"]
         restfile = resultpath / targetfile.split("/")[-1]
         os.system("cp -f %s %s" % (targetfile, restfile))

--- a/setup-data.sh
+++ b/setup-data.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 if [ -n "$1" ]; then
   DEF_TRUNK_PATH="$1"
 else
-  DEF_TRUNK_PATH="DEF_Trunk"
+  DEF_TRUNK_PATH="jobs/DEF_Trunk"
 fi
 
 # Resolve the full path for varlist_json

--- a/setup-data.sh
+++ b/setup-data.sh
@@ -34,4 +34,4 @@ else
 fi
 
 sed -i "s@/home/surface5/vbastri/SPINacc_ref@$FORCING_DATA/vlad_files/vlad_files/@g" $varlist_json
-sed -i "s@/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2/twodeg/@$(readlink -f $TWODEG_DATA)/@g" $varlist_json
+sed -i "s@/home/orchideeshare/igcmg/IGCM/SRF/METEO/CRUJRA/v2.2.2/twodeg/@$(readlink -f $TWODEG_DATA)/@g" $varlist_json


### PR DESCRIPTION
This request

-> solves the  first problem mentioned in issue #98 
https://github.com/CALIPSO-project/SPINacc/issues/98#issue-2817957033

-> adapted the code for writing of unstructured meteo forcing files as well as restart files on pseudo unstructured grid.
-> introduces a remapping of the selected pixels on the pseudo-unstructured grid in the restart files to the global structured masked grid in order to allow step 4 to proceed . to do this I disable the option to allow for duplicated pixel in the cluster breaking the backward compatibility. 

It further updates the README.md to account for changes in the folder structure from the use of the 'jobs' folder

